### PR TITLE
Feature/region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ Reading new data only works after the local app has been started. I'm still look
 1. Ensure [HACS](https://hacs.xyz) is installed.
 2. Add this repository as a custom repository:
    - HACS → Integrations → three dots → **Custom repositories**
-   - Repository URL: `https://github.com/roeli1996/ha-ecowater-custom`
+   - Repository URL: `https://github.com/roeli1996/ha-ecowater-hydrolink`
    - Category: **Integration**
 3. Click **Install** on the Ecowater Hydrolink Custom page in HACS.
 4. Restart Home Assistant.
 
 ### Manual installation
 
-1. Download the `ecowater_hydrolink_custom` folder from the [latest release](https://github.com/roeli1996/ha-ecowater-custom/releases).
+1. Download the `ecowater_hydrolink_custom` folder from the [latest release](https://github.com/roeli1996/ha-ecowater-hydrolink/releases).
 2. Place it in your `custom_components` directory.
 3. Restart Home Assistant.
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,8 @@ This custom integration retrieves real-time data from your Ecowater water soften
 
 US Platform is not tested yet, because I don't have a device on that platform. Please provide me with feedback if you have a device! 
 
----
 ## Known limitations 
 Reading new data only works after the local app has been started. I'm still looking for a way to bypass this.
----
 
 ## 📦 Features
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This custom integration retrieves real-time data from your Ecowater water soften
 
 US Platform is not tested yet, because I don't have a device on that platform. Please provide me with feedback if you have a device! 
 
-## Known limitations 
+## ⚠️ Known limitations 
 Reading new data only works after the local app has been started. I'm still looking for a way to bypass this.
 
 ## 📦 Features

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This custom integration retrieves real-time data from your Ecowater water soften
 
 US Platform is not tested yet, because I don't have a device on that platform. Please provide me with feedback if you have a device! 
 
-## ⚠️ Known limitations 
-Reading new data only works after the local app has been started. I'm still looking for a way to bypass this.
+### ⚠️  
+Reading new data only works after the local app has been started. I think version 1.2.0 should solve the problem. Still need to conform.
 
 ## 📦 Features
 
@@ -119,13 +119,13 @@ The integration automatically renews the token when a 401 response is received. 
 
 ## 📝 Changelog
 
-## V1.1.1 - 2026-02-26
+### V1.1.1 - 2026-02-26
 
-### Fixed
+#### Fixed
 - **Added migration handler** for existing configurations (version 1 → 2). This resolves the *"Migration handler not found"* error that occurred when updating the integration. Existing users are automatically migrated with the region set to `EU`, ensuring they can continue using the integration without interruption.
 - **Note for US users:** If you wish to switch from the EU to the US platform, please remove the integration and add it again with the appropriate region selected. (Region cannot be changed via options at this time.)
 
-### Changed
+#### Changed
 - Internal: enhanced logging during migration for improved debugging and troubleshooting.
 
 ### v1.1.0 – 2026-02-26

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ This custom integration retrieves real-time data from your Ecowater water soften
 > - **Europe** (`app.hydrolinkhome.eu`)  
 > - **US / Other** (`app.hydrolinkhome.com`)
 
-US Platform is not tested yet, because I don't have a device on that platform. Please provide me with feedback if you have a device! 
+> **⚠️ Note for US users:** The US platform has not been tested yet (I don't have a device on that platform). Feedback is welcome if you have a device!
 
-### ⚠️  
-Reading new data only works after the local app has been started. I think version 1.2.0 should solve the problem. Still need to conform.
+### ⚠️ Data refresh improvement
+Previous versions required the Hydrolink mobile app to be opened to wake up the device and get fresh data. **Version 1.2.0 introduces a wake-up mechanism** that sends a signal to the `/live` endpoint before fetching data, making the integration independent of the mobile app. This should resolve the issue. Feedback is appreciated!
 
 ## 📦 Features
 
@@ -40,7 +40,7 @@ Reading new data only works after the local app has been started. I think versio
 
 ### Manual installation
 
-1. Download the `ecowater_hydrolink_custom` folder from the [latest release](https://github.com/roeli1996/ha-ecowater-hydrolink/releases).
+1. Download the `ha-ecowater-hydrolink` folder from the [latest release](https://github.com/roeli1996/ha-ecowater-hydrolink/releases).
 2. Place it in your `custom_components` directory.
 3. Restart Home Assistant.
 
@@ -119,8 +119,19 @@ The integration automatically renews the token when a 401 response is received. 
 
 ## 📝 Changelog
 
-### V1.1.1 - 2026-02-26
+### v1.2.0 - 2026-02-26
+#### Added
+- **Wake-up mechanism**: The integration now sends a signal to the `/live` endpoint before each update to wake up the device, followed by fetching the latest data via `/detail-or-summary`. This ensures that the displayed data is always up-to-date, similar to the web app, and eliminates the need to open the mobile app for fresh data.
 
+#### Changed
+- The coordinator now uses the combination of `/live` (wake-up) and `/detail-or-summary` (data) for every scheduled update once the device ID is known. On the first startup, the device list is still used to determine the ID.
+- Internal restructuring of the data fetching method for better readability and error handling.
+
+#### Notes
+- This change works for both the EU and US platforms.
+- Existing configurations remain intact; no reconfiguration is required.
+
+### v1.1.1 - 2026-02-26
 #### Fixed
 - **Added migration handler** for existing configurations (version 1 → 2). This resolves the *"Migration handler not found"* error that occurred when updating the integration. Existing users are automatically migrated with the region set to `EU`, ensuring they can continue using the integration without interruption.
 - **Note for US users:** If you wish to switch from the EU to the US platform, please remove the integration and add it again with the appropriate region selected. (Region cannot be changed via options at this time.)
@@ -145,9 +156,9 @@ This project is licensed under the MIT License – see the [LICENSE](LICENSE) fi
 
 **Note:** This integration is not officially affiliated with EcoWater or Hydrolink. Use at your own risk.
 
-[releases-shield]: https://img.shields.io/github/v/release/roeli1996/ha-ecowater-custom?style=for-the-badge
-[releases]: https://github.com/roeli1996/ha-ecowater-custom/releases
-[license-shield]: https://img.shields.io/github/license/roeli1996/ha-ecowater-custom?style=for-the-badge
+[releases-shield]: https://img.shields.io/github/v/release/roeli1996/ha-ecowater-hydrolink?style=for-the-badge
+[releases]: https://github.com/roeli1996/ha-ecowater-hydrolink/releases
+[license-shield]: https://img.shields.io/github/license/roeli1996/ha-ecowater-hydrolink?style=for-the-badge
 [hacs]: https://hacs.xyz
 [hacsbadge]: https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge
 [author-shield]: https://img.shields.io/badge/Author-roeli1996-blue?style=for-the-badge

--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ The integration automatically renews the token when a 401 response is received. 
 
 ## 📝 Changelog
 
+## V1.1.1 - 2026-02-26
+
+### Fixed
+- **Added migration handler** for existing configurations (version 1 → 2). This resolves the *"Migration handler not found"* error that occurred when updating the integration. Existing users are automatically migrated with the region set to `EU`, ensuring they can continue using the integration without interruption.
+- **Note for US users:** If you wish to switch from the EU to the US platform, please remove the integration and add it again with the appropriate region selected. (Region cannot be changed via options at this time.)
+
+### Changed
+- Internal: enhanced logging during migration for improved debugging and troubleshooting.
+
 ### v1.1.0 – 2026-02-26
 - **Added region selection** (EU / US) during configuration.  
 - Updated API endpoints for US platform (`app.hydrolinkhome.com`).  

--- a/custom_components/ecowater_hydrolink_custom/config_flow.py
+++ b/custom_components/ecowater_hydrolink_custom/config_flow.py
@@ -1,3 +1,5 @@
+"""Config flow for Ecowater Hydrolink Custom integration."""
+import logging
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
@@ -13,10 +15,12 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 class EcowaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Ecowater Hydrolink Custom."""
 
-    VERSION = 2  # Increment version because we changed the data schema
+    VERSION = 2
 
     async def async_step_user(self, user_input=None):
         """Step called when the user adds the integration."""
@@ -57,6 +61,20 @@ class EcowaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def async_get_options_flow(config_entry):
         """Return the options flow handler."""
         return EcowaterOptionsFlowHandler(config_entry)
+
+    async def async_migrate_entry(self, hass, config_entry: config_entries.ConfigEntry):
+        """Migrate old entry."""
+        _LOGGER.debug("Migrating from version %s", config_entry.version)
+
+        if config_entry.version == 1:
+            # Version 1 had no region; add EU as default
+            new_data = {**config_entry.data}
+            new_data[CONF_REGION] = REGION_EU
+            config_entry.version = 2
+            hass.config_entries.async_update_entry(config_entry, data=new_data)
+            _LOGGER.debug("Migration to version 2 complete")
+
+        return True
 
 
 class EcowaterOptionsFlowHandler(config_entries.OptionsFlow):

--- a/custom_components/ecowater_hydrolink_custom/coordinator.py
+++ b/custom_components/ecowater_hydrolink_custom/coordinator.py
@@ -31,10 +31,11 @@ class EcowaterCoordinator(DataUpdateCoordinator):
     def __init__(self, hass, entry):
         """Initialize the coordinator with dynamic interval and region."""
         self.entry = entry
-        self.region = entry.data.get(CONF_REGION, REGION_EU)  # default to EU for existing entries
+        self.region = entry.data.get(CONF_REGION, REGION_EU)
         self.base_url = BASE_URLS[self.region]
         self.login_url = f"{self.base_url}/auth/login"
-        self.data_url = f"{self.base_url}/devices?all=false&per_page=200"
+        self.devices_list_url = f"{self.base_url}/devices?all=false&per_page=200"
+        self.device_id = None
 
         interval = entry.options.get(
             SCAN_INTERVAL_MINUTES,
@@ -96,8 +97,67 @@ class EcowaterCoordinator(DataUpdateCoordinator):
             _LOGGER.exception("Authentication failed for Ecowater")
             return None
 
+    async def _fetch_device_list(self, headers):
+        """Fetch the list of devices to obtain the device ID."""
+        response = await self._async_request("GET", self.devices_list_url, headers=headers)
+        response.raise_for_status()
+        json_data = await response.json()
+        devices = json_data.get("data", [])
+        if not devices:
+            raise UpdateFailed("No devices found in Ecowater account")
+        return devices[0]
+
+    async def _parse_device_data(self, device):
+        """Extract sensor data from a device object (from /devices endpoint)."""
+        props = device.get("properties", {})
+        enriched = device.get("enriched_data", {})
+        wt = enriched.get("water_treatment", {})
+        wts = wt.get("water_treatment_status", {})
+        dealership = device.get("dealership", {})
+
+        def get_prop_value(key, subkey="value", default=None):
+            prop = props.get(key, {})
+            return prop.get(subkey, default)
+
+        def get_prop_converted(key, default=None):
+            prop = props.get(key, {})
+            return prop.get("converted_value", default)
+
+        return {
+            "last_update": dt_util.now(),
+            "salt_level_percent": wt.get("salt_level_percent"),
+            "salt_level_rounded": wt.get("salt_level", {}).get("salt_level_percent_rounded"),
+            "out_of_salt_days": get_prop_value("out_of_salt_estimate_days"),
+            "low_salt_trip_days": get_prop_value("low_salt_trip_level_days"),
+            "service_reminder": wts.get("service_reminder_message"),
+            "water_used_today": get_prop_converted("gallons_used_today"),
+            "total_water_used": wt.get("total_water_used", {}).get("value"),
+            "water_available": wt.get("treated_water_available", {}).get("value"),
+            "current_flow": get_prop_converted("current_water_flow_gpm"),
+            "avg_daily_use": get_prop_converted("avg_daily_use_gals"),
+            "hardness": get_prop_value("hardness_grains"),
+            "total_regens": get_prop_value("total_regens"),
+            "manual_regens": get_prop_value("manual_regens"),
+            "days_since_regen": wt.get("days_since_last_recharge") or get_prop_value("days_since_last_regen"),
+            "avg_days_between_regens": get_prop_value("avg_days_between_regens"),
+            "avg_salt_per_regen": get_prop_converted("avg_salt_per_regen_lbs"),
+            "model": wt.get("model") or get_prop_value("model_description"),
+            "serial": device.get("serial_number"),
+            "software_version": get_prop_value("base_software_version"),
+            "rssi": wt.get("rf_signal_strength_dbm"),
+            "wifi_ssid": wt.get("wifi_ssid_name"),
+            "days_in_operation": get_prop_value("days_in_operation"),
+            "power_outages": get_prop_value("power_outage_count"),
+            "dealer_name": dealership.get("name"),
+            "dealer_phone": dealership.get("phone_number"),
+            "is_regenerating": wt.get("regeneration_status") != "none" if wt.get("regeneration_status") else False,
+            "salt_alert": wts.get("salt_level_alert", False),
+            "leak_alert": wts.get("flow_monitor_alert", False),
+            "error_alert": wts.get("error_code_alert", False),
+        }
+
     async def _fetch_data(self):
-        """Internal data fetching."""
+        """Internal data fetching. Uses wake-up + detail if device ID known, else falls back to device list."""
         if not self.token:
             self.token = await self._get_token()
 
@@ -108,75 +168,34 @@ class EcowaterCoordinator(DataUpdateCoordinator):
         headers["Authorization"] = f"Bearer {self.token}"
 
         try:
-            response = await self._async_request("GET", self.data_url, headers=headers)
-            _LOGGER.debug("Response status: %s", response.status)
+            # If we don't have a device ID yet, fetch the device list and extract ID + data
+            if self.device_id is None:
+                device = await self._fetch_device_list(headers)
+                self.device_id = device.get("id")
+                _LOGGER.debug("Device ID obtained: %s", self.device_id)
+                return await self._parse_device_data(device)
 
-            if response.status == 401:
-                _LOGGER.debug("Token expired, requesting new token")
-                self.token = await self._get_token()
-                if not self.token:
-                    raise UpdateFailed("Token renewal failed")
-                headers["Authorization"] = f"Bearer {self.token}"
-                response = await self._async_request("GET", self.data_url, headers=headers)
-                _LOGGER.debug("New response status: %s", response.status)
+            # Device ID known: first send wake-up call to /live, then fetch fresh data from /detail-or-summary
+            try:
+                live_url = f"{self.base_url}/devices/{self.device_id}/live"
+                await self._async_request("GET", live_url, headers=headers)
+                _LOGGER.debug("Wake-up call sent to device %s", self.device_id)
+            except Exception as wake_err:
+                _LOGGER.warning("Wake-up call failed, continuing with data fetch: %s", wake_err)
 
+            # Fetch current data from detail-or-summary
+            detail_url = f"{self.base_url}/devices/{self.device_id}/detail-or-summary"
+            response = await self._async_request("GET", detail_url, headers=headers)
             response.raise_for_status()
             json_data = await response.json()
-            _LOGGER.debug("JSON response received")
+            _LOGGER.debug("Detail data received for device %s", self.device_id)
 
-            devices = json_data.get("data", [])
-            if not devices:
-                raise UpdateFailed("No devices found in Ecowater account")
+            # Extract the device object from the response
+            device = json_data.get("device")
+            if not device:
+                raise UpdateFailed("No device data found in detail response")
 
-            dev = devices[0]
-            props = dev.get("properties", {})
-            enriched = dev.get("enriched_data", {})
-            wt = enriched.get("water_treatment", {})
-            wts = wt.get("water_treatment_status", {})
-            dealership = dev.get("dealership", {})
-
-            def get_prop_value(key, subkey="value", default=None):
-                prop = props.get(key, {})
-                return prop.get(subkey, default)
-
-            def get_prop_converted(key, default=None):
-                prop = props.get(key, {})
-                return prop.get("converted_value", default)
-
-            data = {
-                "last_update": dt_util.now(),
-                "salt_level_percent": wt.get("salt_level_percent"),
-                "salt_level_rounded": wt.get("salt_level", {}).get("salt_level_percent_rounded"),
-                "out_of_salt_days": get_prop_value("out_of_salt_estimate_days"),
-                "low_salt_trip_days": get_prop_value("low_salt_trip_level_days"),
-                "service_reminder": wts.get("service_reminder_message"),
-                "water_used_today": get_prop_converted("gallons_used_today"),
-                "total_water_used": wt.get("total_water_used", {}).get("value"),
-                "water_available": wt.get("treated_water_available", {}).get("value"),
-                "current_flow": get_prop_converted("current_water_flow_gpm"),
-                "avg_daily_use": get_prop_converted("avg_daily_use_gals"),
-                "hardness": get_prop_value("hardness_grains"),
-                "total_regens": get_prop_value("total_regens"),
-                "manual_regens": get_prop_value("manual_regens"),
-                "days_since_regen": wt.get("days_since_last_recharge") or get_prop_value("days_since_last_regen"),
-                "avg_days_between_regens": get_prop_value("avg_days_between_regens"),
-                "avg_salt_per_regen": get_prop_converted("avg_salt_per_regen_lbs"),
-                "model": wt.get("model") or get_prop_value("model_description"),
-                "serial": dev.get("serial_number"),
-                "software_version": get_prop_value("base_software_version"),
-                "rssi": wt.get("rf_signal_strength_dbm"),
-                "wifi_ssid": wt.get("wifi_ssid_name"),
-                "days_in_operation": get_prop_value("days_in_operation"),
-                "power_outages": get_prop_value("power_outage_count"),
-                "dealer_name": dealership.get("name"),
-                "dealer_phone": dealership.get("phone_number"),
-                "is_regenerating": wt.get("regeneration_status") != "none" if wt.get("regeneration_status") else False,
-                "salt_alert": wts.get("salt_level_alert", False),
-                "leak_alert": wts.get("flow_monitor_alert", False),
-                "error_alert": wts.get("error_code_alert", False),
-            }
-            _LOGGER.debug("Data assembled: %s", {k: v for k, v in data.items() if k not in ["serial", "dealer_phone"]})
-            return data
+            return await self._parse_device_data(device)
 
         except Exception as ex:
             _LOGGER.exception("Error fetching Ecowater data")

--- a/custom_components/ecowater_hydrolink_custom/manifest.json
+++ b/custom_components/ecowater_hydrolink_custom/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ecowater_hydrolink_custom",
   "name": "Ecowater Hydrolink Custom",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "documentation": "https://github.com/roeli1996/ha-ecowater-custom",
   "issue_tracker": "https://github.com/roeli1996/ha-ecowater-custom/issues",
   "dependencies": [],
@@ -10,4 +10,5 @@
   "config_flow": true,
   "requirements": ["aiohttp", "async_timeout"]
 }
+
 

--- a/custom_components/ecowater_hydrolink_custom/manifest.json
+++ b/custom_components/ecowater_hydrolink_custom/manifest.json
@@ -1,14 +1,13 @@
 {
   "domain": "ecowater_hydrolink_custom",
   "name": "Ecowater Hydrolink Custom",
-  "version": "1.1.1",
-  "documentation": "https://github.com/roeli1996/ha-ecowater-custom",
-  "issue_tracker": "https://github.com/roeli1996/ha-ecowater-custom/issues",
+  "version": "1.2.0",
+  "documentation": "https://github.com/roeli1996/ha-ecowater-hydrolink",
+  "issue_tracker": "https://github.com/roeli1996/ha-ecowater-hydrolink/issues",
   "dependencies": [],
   "codeowners": ["@roeli1996"],
   "iot_class": "cloud_polling",
   "config_flow": true,
   "requirements": ["aiohttp", "async_timeout"]
 }
-
 


### PR DESCRIPTION
## [1.2.0] - 2026-02-26

### Added
- **Wake-up mechanisme**: De integratie stuurt nu vóór elke update een signaal naar het `/live`-endpoint om het apparaat te activeren, gevolgd door het ophalen van de meest recente gegevens via `/detail-or-summary`. Dit zorgt ervoor dat de getoonde data altijd up-to-date is, vergelijkbaar met de webapp.

### Changed
- De coordinator gebruikt nu voor elke geplande update de combinatie van `/live` (wake-up) en `/detail-or-summary` (data) zodra het apparaat-ID bekend is. Bij de eerste start wordt nog steeds de apparaatlijst gebruikt om het ID te bepalen.
- Interne herstructurering van de data-ophaalmethode voor betere leesbaarheid en foutafhandeling.

### Fixed
- Geen specifieke bugfixes; deze versie verbetert de betrouwbaarheid van de dataverversing.

### Notes
- Deze wijziging werkt voor zowel het EU- als het US-platform.
- Bestaande configuraties blijven behouden; er is geen herconfiguratie nodig.