### PR TITLE
Feature/unit system

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,18 @@ This custom integration retrieves real-time data from your Ecowater water soften
 > - **Europe** (`app.hydrolinkhome.eu`)  
 > - **US / Other** (`app.hydrolinkhome.com`)
 
+> **📏 Unit system selection:** Starting from version 1.3.0, you can choose between metric (liters, kg) and imperial (gallons, lbs) units during configuration or via options. The integration automatically displays the correct values based on your preference. The alternative unit is available as an attribute on each sensor (see below).
 
-### ⚠️ Data refresh improvement
-Previous versions required the Hydrolink mobile app to be opened to wake up the device and get fresh data. **Version 1.2.0 introduces a wake-up mechanism** that sends a signal to the `/live` endpoint before fetching data, making the integration independent of the mobile app. This should resolve the issue. Feedback is appreciated!
 
 ## 📦 Features
 
 - Extensive sensor values: salt percentage, water usage (today/total), estimated days until salt runs out, flow rate, hardness, regeneration count, and more.
-- Binary sensors for regeneration status, salt alerts, leak alerts, and system errors.
+- Binary sensors for regeneration status, salt alerts, leak alerts, system errors, and audible alarm status.
 - Automatic API token renewal.
 - Configurable update interval (via options).
 - Multi-region support (EU and US).
+- Selectable unit system (metric or imperial) with the alternative unit available as an attribute on each sensor.
+- Wake-up mechanism (since v1.2.0) that polls the `/live` endpoint before each update to ensure fresh data, eliminating the need to open the mobile app.
 
 ## 🔧 Installation
 
@@ -39,7 +40,7 @@ Previous versions required the Hydrolink mobile app to be opened to wake up the 
 
 ### Manual installation
 
-1. Download the `ha-ecowater-hydrolink` folder from the [latest release](https://github.com/roeli1996/ha-ecowater-hydrolink/releases).
+1. Download the `ecowater_hydrolink_hydrolink` folder from the [latest release](https://github.com/roeli1996/ha-ecowater-hydrolink/releases).
 2. Place it in your `custom_components` directory.
 3. Restart Home Assistant.
 
@@ -51,48 +52,56 @@ The integration is fully configured via the Home Assistant user interface.
 2. Click **Add Integration** and search for "Ecowater Hydrolink Custom".
 3. Enter your login credentials (email and password of your Hydrolink account).
 4. **Select your region** (EU or US). This determines the correct API endpoint.
-5. Set the desired **update interval** in minutes (default 5 minutes; 1 minute also works).
-6. Click **Submit**.
+5. **Select your preferred unit system** (metric or imperial).
+6. Set the desired **update interval** in minutes (default 5 minutes; 1 minute also works).
+7. Click **Submit**.
 
 After successful configuration, all sensors and binary sensors will appear automatically under one device.
 
 ### Changing options
 
-After installation, you can adjust the update interval via:  
+After installation, you can adjust the update interval and unit system via:  
 **Device → three dots → Options**
+
+> **Note:** When you change the unit system, the displayed values may not update immediately due to Home Assistant's entity state cache. After saving the options, the integration reloads and the new values will appear on the next sensor update. You can also force a refresh by restarting the integration or waiting for the next scheduled poll.
 
 ## 📊 Sensors
 
-The integration adds the following sensors (all grouped under one device):
+The integration adds the following sensors (all grouped under one device). Units depend on your selected unit system (metric shown below; imperial units will be gallons, gpm, lbs). For each sensor that supports both unit systems, the alternative value is available as an attribute (e.g., `imperial_value` or `metric_value`).
 
-| Sensor | Description | Unit | Device class |
-|--------|-------------|------|--------------|
-| `last_update` | Timestamp of last successful update | | timestamp |
-| `salt_level_percent` | Current salt level | % | |
-| `salt_level_rounded` | Rounded salt level (from API) | % | |
-| `out_of_salt_days` | Estimated days until salt runs out | days | |
-| `low_salt_trip_days` | Low salt trip level (device setting) | days | |
-| `service_reminder` | Service reminder (e.g. "12 months") | | |
-| `water_used_today` | Water usage today | L | water |
-| `total_water_used` | Total water usage since installation | L | water |
-| `water_available` | Amount of treated water still available | L | water |
-| `current_flow` | Current flow rate | L/min | |
-| `avg_daily_use` | Average daily water usage | L | water |
-| `hardness` | Water hardness setting | gpg | |
-| `total_regens` | Total number of regenerations | | |
-| `manual_regens` | Number of manual regenerations | | |
-| `days_since_regen` | Days since last regeneration | days | |
-| `avg_days_between_regens` | Average days between regenerations | days | |
-| `avg_salt_per_regen` | Average salt consumption per regeneration | kg | |
-| `model` | Water softener model | | |
-| `serial` | Serial number | | |
-| `software_version` | Controller software version | | |
-| `rssi` | Wi-Fi signal strength | dBm | signal_strength |
-| `wifi_ssid` | Wi-Fi network name | | |
-| `days_in_operation` | Days in operation | days | |
-| `power_outages` | Number of power outages | | |
-| `dealer_name` | Dealer name | | |
-| `dealer_phone` | Dealer phone number | | |
+| Sensor | Description | Unit (metric) | Device class | Attributes |
+|--------|-------------|---------------|--------------|------------|
+| `last_update` | Timestamp of last successful update | | timestamp | – |
+| `salt_level_percent` | Current salt level | % | | – |
+| `salt_level_rounded` | Rounded salt level (from API) | % | | – |
+| `out_of_salt_days` | Estimated days until salt runs out | days | | – |
+| `low_salt_trip_days` | Low salt trip level (device setting) | days | | – |
+| `service_reminder` | Service reminder (e.g. "12 months") | | | – |
+| `water_used_today` | Water usage today | L | water | `imperial_value` / `metric_value` |
+| `total_water_used` | Total water usage since installation | L | water | `imperial_value` / `metric_value` |
+| `water_available` | Amount of treated water still available | L | water | `imperial_value` / `metric_value` |
+| `current_flow` | Current flow rate | L/min | | `imperial_value` / `metric_value` |
+| `avg_daily_use` | Average daily water usage | L | water | `imperial_value` / `metric_value` |
+| `hardness` | Water hardness setting | gpg | | – |
+| `total_regens` | Total number of regenerations | | | – |
+| `manual_regens` | Number of manual regenerations | | | – |
+| `days_since_regen` | Days since last regeneration | days | | – |
+| `avg_days_between_regens` | Average days between regenerations | days | | – |
+| `avg_salt_per_regen` | Average salt consumption per regeneration | kg | | `imperial_value` / `metric_value` |
+| `model` | Water softener model | | | – |
+| `serial` | Serial number | | | – |
+| `software_version` | Controller software version | | | – |
+| `rssi` | Wi-Fi signal strength | dBm | signal_strength | – |
+| `wifi_ssid` | Wi-Fi network name | | | – |
+| `days_in_operation` | Days in operation | days | | – |
+| `power_outages` | Number of power outages | | | – |
+| `dealer_name` | Dealer name | | | – |
+| `dealer_phone` | Dealer phone number | | | – |
+| `rock_removed_since_regen` | Hardness removed since last regeneration | kg | | `imperial_value` / `metric_value` |
+| `total_rock_removed` | Total hardness removed over lifetime | kg | | `imperial_value` / `metric_value` |
+| `total_salt_use` | Total salt consumed over lifetime | kg | | `imperial_value` / `metric_value` |
+
+> **Note:** Attributes containing the alternative unit only appear after the sensor has received at least one update with the new unit setting. If you change the unit system, the attributes may be empty until the next data refresh.
 
 ## 🚨 Binary sensors
 
@@ -102,6 +111,7 @@ The integration adds the following sensors (all grouped under one device):
 | `salt_alert` | Salt low alert | problem |
 | `leak_alert` | Leak detected | problem |
 | `error_alert` | System error | problem |
+| `alarm_beeping` | Audible alarm is active | sound |
 
 ## ❓ Troubleshooting
 
@@ -112,11 +122,38 @@ The integration adds the following sensors (all grouped under one device):
 ### Token expiration
 The integration automatically renews the token when a 401 response is received. If this fails, check your internet connection.
 
+### Unit change does not update values immediately
+After changing the unit system in the options, the integration reloads. However, due to Home Assistant's entity state cache, the displayed values may still show the old unit for a short time. 
+
+### Attributes not showing
+Attributes containing the alternative unit are only populated after the sensor has received a new value following the unit change. 
+
+### Unrealistic values for certain sensors
+Some sensors, such as `rock_removed_since_regen`, `total_rock_removed`, and `total_salt_use`, may display values that seem unrealistic (e.g., very high numbers for a newly installed device). These values come directly from the Hydrolink API and are not calculated or modified by the integration. They reflect the data provided by the manufacturer's cloud service.
+
 ### Known limitations
-- Only tested on an **eVO REFINER POWER** (EU). US devices may have slight differences; feedback is welcome.
 - Not tested on multiple devices under a single account.
 
 ## 📝 Changelog
+
+### v1.3.0 - 2026-02-26
+#### Added
+- **Unit system selection**: Choose between metric (liters, kg) and imperial (gallons, lbs) during configuration or via options. The integration automatically displays the correct values based on your preference.
+- **Alternative unit as attribute**: For all unit‑dependent sensors, the value in the other unit system is now available as an attribute (e.g., `imperial_value` or `metric_value`).
+- **New sensors**:
+  - `alarm_beeping` (binary sensor) – indicates if the audible alarm is active.
+  - `rock_removed_since_regen` – hardness removed since the last regeneration.
+  - `total_rock_removed` – total hardness removed over the device's lifetime.
+  - `total_salt_use` – total salt consumed over the device's lifetime.
+- **Extended options** to include unit system selection.
+
+#### Changed
+- Updated sensor handling to dynamically display the correct unit and provide the alternative via attributes.
+- Improved documentation and troubleshooting notes regarding unit changes and attributes.
+
+#### Notes
+- Existing configurations will have the unit system default to metric. You can change it via options.
+- If you upgrade from a previous version, you may need to remove and re‑add the integration for the new sensors to appear.
 
 ### v1.2.0 - 2026-02-26
 #### Added
@@ -147,6 +184,9 @@ The integration automatically renews the token when a 401 response is received. 
 ### v1.0.0 – 2026-02-24
 - Initial release (EU only).
 
+> **Important note for users upgrading from older versions:**  
+> Due to the addition of the unit system and new sensors, it is recommended to remove the integration and add it again after upgrading to v1.3.0. This ensures that all new sensors are created correctly and that the unit selection works as expected. Your historical data will not be lost.
+
 ## 📝 License
 
 This project is licensed under the MIT License – see the [LICENSE](LICENSE) file for details.
@@ -155,9 +195,9 @@ This project is licensed under the MIT License – see the [LICENSE](LICENSE) fi
 
 **Note:** This integration is not officially affiliated with EcoWater or Hydrolink. Use at your own risk.
 
-[releases-shield]: https://img.shields.io/github/v/release/roeli1996/ha-ecowater-hydrolink?style=for-the-badge
-[releases]: https://github.com/roeli1996/ha-ecowater-hydrolink/releases
-[license-shield]: https://img.shields.io/github/license/roeli1996/ha-ecowater-hydrolink?style=for-the-badge
+[releases-shield]: https://img.shields.io/github/v/release/roeli1996/ha-ecowater-custom?style=for-the-badge
+[releases]: https://github.com/roeli1996/ha-ecowater-custom/releases
+[license-shield]: https://img.shields.io/github/license/roeli1996/ha-ecowater-custom?style=for-the-badge
 [hacs]: https://hacs.xyz
 [hacsbadge]: https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge
 [author-shield]: https://img.shields.io/badge/Author-roeli1996-blue?style=for-the-badge

--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ This custom integration retrieves real-time data from your Ecowater water soften
 - Selectable unit system (metric or imperial) with the alternative unit available as an attribute on each sensor.
 - Wake-up mechanism (since v1.2.0) that polls the `/live` endpoint before each update to ensure fresh data, eliminating the need to open the mobile app.
 
+## 🌐 Language support
+
+The integration is translated into several languages and will automatically display sensor and configuration names in your Home Assistant language if available.
+
+Currently supported languages:
+- 🇳🇱 **Dutch** (Nederlands)
+- 🇬🇧 **English**
+- 🇫🇷 **French** (Français)
+- 🇩🇪 **German** (Deutsch)
+- 🇮🇹 **Italian** (Italiano)
+- 🇵🇱 **Polish** (Polski)
+- 🇪🇸 **Spanish** (Español)
+- 🇵🇹 **Portuguese** (Português)
+
+If your language is not listed, the interface will fall back to English. Translations are community‑contributed – feel free to help add more!
+
 ## 🔧 Installation
 
 ### Via HACS (recommended)

--- a/custom_components/ecowater_hydrolink_custom/__init__.py
+++ b/custom_components/ecowater_hydrolink_custom/__init__.py
@@ -1,3 +1,4 @@
+"""Init for Ecowater Hydrolink Custom integration."""
 import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -9,40 +10,33 @@ from .coordinator import EcowaterCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Stel de Ecowater Hydrolink Custom integratie in vanuit een config entry."""
-
-    # Maak de coordinator aan
+    """Set up Ecowater Hydrolink Custom from a config entry."""
     coordinator = EcowaterCoordinator(hass, entry)
 
     try:
-        # Haal de eerste keer data op. Als dit faalt (bijv. geen internet),
-        # markeert HA de integratie als 'niet gereed' en probeert het later opnieuw.
         await coordinator.async_config_entry_first_refresh()
     except Exception as ex:
-        raise ConfigEntryNotReady(f"Fout bij eerste verbinding met Ecowater API: {ex}")
+        raise ConfigEntryNotReady(f"Error connecting to Ecowater API: {ex}") from ex
 
-    # Sla de coordinator op in de centrale data-opslag van Home Assistant
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    # Start de platforms (sensor.py en binary_sensor.py)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    # Voeg een listener toe voor het geval je de opties (zoals scan_interval) aanpast
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
     return True
 
 async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
-    """Herlaad de integratie wanneer de opties worden gewijzigd via de UI."""
+    """Reload integration when options are changed."""
+    _LOGGER.debug("update_listener: options changed for entry %s, reloading", entry.entry_id)
     await hass.config_entries.async_reload(entry.entry_id)
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Verwijder de integratie en stop alle actieve processen."""
+    """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
-        # Ruim de opgeslagen coordinator data op
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/custom_components/ecowater_hydrolink_custom/binary_sensor.py
+++ b/custom_components/ecowater_hydrolink_custom/binary_sensor.py
@@ -1,5 +1,6 @@
 import logging
 from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -10,23 +11,26 @@ async def async_setup_entry(hass, entry, async_add_entities):
     _LOGGER.debug("Setting up Ecowater binary sensors")
 
     binary_sensors = [
-        EcoWaterBinarySensor(coordinator, "Regenerating", "is_regenerating", BinarySensorDeviceClass.RUNNING),
-        EcoWaterBinarySensor(coordinator, "Salt Alert", "salt_alert", BinarySensorDeviceClass.PROBLEM),
-        EcoWaterBinarySensor(coordinator, "Leak Alert", "leak_alert", BinarySensorDeviceClass.PROBLEM),
-        EcoWaterBinarySensor(coordinator, "Error Alert", "error_alert", BinarySensorDeviceClass.PROBLEM),
+        EcoWaterBinarySensor(coordinator, "is_regenerating", BinarySensorDeviceClass.RUNNING),
+        EcoWaterBinarySensor(coordinator, "salt_alert", BinarySensorDeviceClass.PROBLEM),
+        EcoWaterBinarySensor(coordinator, "leak_alert", BinarySensorDeviceClass.PROBLEM),
+        EcoWaterBinarySensor(coordinator, "error_alert", BinarySensorDeviceClass.PROBLEM),
+        EcoWaterBinarySensor(coordinator, "alarm_beeping", BinarySensorDeviceClass.SOUND),
     ]
 
     _LOGGER.debug("Aantal binary sensors om toe te voegen: %d", len(binary_sensors))
     async_add_entities(binary_sensors)
     _LOGGER.debug("Binary sensors toegevoegd aan Home Assistant")
 
-class EcoWaterBinarySensor(BinarySensorEntity):
+
+class EcoWaterBinarySensor(CoordinatorEntity, BinarySensorEntity):
     """Vertegenwoordigt een Ecowater binary sensor."""
 
-    def __init__(self, coordinator, name, data_key, device_class):
-        self.coordinator = coordinator
+    def __init__(self, coordinator, data_key, device_class):
+        super().__init__(coordinator)
         self._data_key = data_key
-        self._attr_name = f"Ecowater {name}"
+        self._attr_translation_key = data_key
+        self._attr_has_entity_name = True
         self._attr_device_class = device_class
         self._attr_unique_id = f"{DOMAIN}_bin_{data_key}_{coordinator.entry.entry_id}"
         self._attr_device_info = {
@@ -50,9 +54,3 @@ class EcoWaterBinarySensor(BinarySensorEntity):
     def available(self):
         """Geef beschikbaarheid op basis van de coordinator."""
         return self.coordinator.last_update_success
-
-    async def async_added_to_hass(self):
-        """Stel listener in voor coordinator updates."""
-        self.async_on_remove(
-            self.coordinator.async_add_listener(self.async_write_ha_state)
-        )

--- a/custom_components/ecowater_hydrolink_custom/config_flow.py
+++ b/custom_components/ecowater_hydrolink_custom/config_flow.py
@@ -11,6 +11,9 @@ from .const import (
     CONF_REGION,
     REGION_EU,
     REGION_US,
+    CONF_UNIT_SYSTEM,
+    UNIT_METRIC,
+    UNIT_OPTIONS,
     SCAN_INTERVAL_MINUTES,
     DEFAULT_SCAN_INTERVAL,
 )
@@ -27,13 +30,11 @@ class EcowaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            # Create the entry with the selected region
             return self.async_create_entry(
                 title="Ecowater Hydrolink Custom",
                 data=user_input
             )
 
-        # Schema with region selection
         data_schema = vol.Schema(
             {
                 vol.Required(CONF_USERNAME): str,
@@ -44,6 +45,7 @@ class EcowaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         REGION_US: "US / Other (app.hydrolinkhome.com)",
                     }
                 ),
+                vol.Required(CONF_UNIT_SYSTEM, default=UNIT_METRIC): vol.In(UNIT_OPTIONS),
                 vol.Optional(
                     SCAN_INTERVAL_MINUTES, default=DEFAULT_SCAN_INTERVAL
                 ): int,
@@ -59,21 +61,16 @@ class EcowaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
-        """Return the options flow handler."""
         return EcowaterOptionsFlowHandler(config_entry)
 
-    async def async_migrate_entry(self, hass, config_entry: config_entries.ConfigEntry):
+    async def async_migrate_entry(self, hass, config_entry):
         """Migrate old entry."""
         _LOGGER.debug("Migrating from version %s", config_entry.version)
-
         if config_entry.version == 1:
-            # Version 1 had no region; add EU as default
-            new_data = {**config_entry.data}
-            new_data[CONF_REGION] = REGION_EU
+            new_data = {**config_entry.data, CONF_REGION: REGION_EU}
             config_entry.version = 2
             hass.config_entries.async_update_entry(config_entry, data=new_data)
             _LOGGER.debug("Migration to version 2 complete")
-
         return True
 
 
@@ -89,15 +86,20 @@ class EcowaterOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        # Determine current scan interval
-        current_value = self.config_entry.options.get(
+        # Determine current values
+        current_unit = self.config_entry.options.get(
+            CONF_UNIT_SYSTEM,
+            self.config_entry.data.get(CONF_UNIT_SYSTEM, UNIT_METRIC)
+        )
+        current_interval = self.config_entry.options.get(
             SCAN_INTERVAL_MINUTES,
             self.config_entry.data.get(SCAN_INTERVAL_MINUTES, DEFAULT_SCAN_INTERVAL)
         )
 
         data_schema = vol.Schema(
             {
-                vol.Optional(SCAN_INTERVAL_MINUTES, default=current_value): int,
+                vol.Required(CONF_UNIT_SYSTEM, default=current_unit): vol.In(UNIT_OPTIONS),
+                vol.Optional(SCAN_INTERVAL_MINUTES, default=current_interval): int,
             }
         )
 

--- a/custom_components/ecowater_hydrolink_custom/const.py
+++ b/custom_components/ecowater_hydrolink_custom/const.py
@@ -11,14 +11,20 @@ CONF_REGION = "region"
 REGION_EU = "EU"
 REGION_US = "US"
 
+# Unit system selection
+CONF_UNIT_SYSTEM = "unit_system"
+UNIT_METRIC = "metric"
+UNIT_IMPERIAL = "imperial"
+UNIT_OPTIONS = {
+    UNIT_METRIC: "Metric (liters, kg)",
+    UNIT_IMPERIAL: "Imperial (gallons, lbs)",
+}
+
 # Base URLs per region
 BASE_URLS = {
     REGION_EU: "https://api.hydrolinkhome.eu/v1",
-    REGION_US: "https://api.hydrolinkhome.com/v1",  # Assuming API structure is identical
+    REGION_US: "https://api.hydrolinkhome.com/v1",
 }
-
-# These are now constructed dynamically in coordinator.py
-# LOGIN_URL and DATA_URL are removed from here.
 
 SCAN_INTERVAL_MINUTES = "scan_interval_minutes"
 DEFAULT_SCAN_INTERVAL = 5
@@ -27,11 +33,10 @@ HEADERS = {
     "Accept": "application/json, text/plain, */*",
     "Accept-Language": "nl-NL,nl;q=0.9,en-US;q=0.8,en;q=0.7",
     "Content-Type": "application/json",
-    "Origin": "https://app.hydrolinkhome.eu",  # This may differ per region; we keep it generic
+    "Origin": "https://app.hydrolinkhome.eu",
     "Referer": "https://app.hydrolinkhome.eu/",
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
     "X-Requested-With": "XMLHttpRequest",
 }
 
-# Platforms that this integration supports
 PLATFORMS = ["sensor", "binary_sensor"]

--- a/custom_components/ecowater_hydrolink_custom/coordinator.py
+++ b/custom_components/ecowater_hydrolink_custom/coordinator.py
@@ -18,6 +18,8 @@ from .const import (
     REGION_EU,
     CONF_USERNAME,
     CONF_PASSWORD,
+    CONF_UNIT_SYSTEM,
+    UNIT_METRIC,
     HEADERS,
     SCAN_INTERVAL_MINUTES,
     DEFAULT_SCAN_INTERVAL,
@@ -32,6 +34,13 @@ class EcowaterCoordinator(DataUpdateCoordinator):
         """Initialize the coordinator with dynamic interval and region."""
         self.entry = entry
         self.region = entry.data.get(CONF_REGION, REGION_EU)
+        self.unit_system = entry.options.get(CONF_UNIT_SYSTEM, entry.data.get(CONF_UNIT_SYSTEM, UNIT_METRIC))
+        _LOGGER.debug(
+            "Coordinator unit_system = %s (uit options: %s, uit data: %s)",
+            self.unit_system,
+            entry.options.get(CONF_UNIT_SYSTEM),
+            entry.data.get(CONF_UNIT_SYSTEM)
+        )
         self.base_url = BASE_URLS[self.region]
         self.login_url = f"{self.base_url}/auth/login"
         self.devices_list_url = f"{self.base_url}/devices?all=false&per_page=200"
@@ -42,8 +51,8 @@ class EcowaterCoordinator(DataUpdateCoordinator):
             entry.data.get(SCAN_INTERVAL_MINUTES, DEFAULT_SCAN_INTERVAL)
         )
         _LOGGER.debug(
-            "Coordinator for region %s, update interval: %s minutes -> %s",
-            self.region, interval, timedelta(minutes=interval)
+            "Coordinator for region %s, unit system %s, update interval: %s minutes -> %s",
+            self.region, self.unit_system, interval, timedelta(minutes=interval)
         )
         super().__init__(
             hass,
@@ -123,24 +132,44 @@ class EcowaterCoordinator(DataUpdateCoordinator):
             prop = props.get(key, {})
             return prop.get("converted_value", default)
 
-        return {
+        # Helper to get measurement based on unit system
+        def get_measurement(prop_key, default=None):
+            if self.unit_system == UNIT_METRIC:
+                return get_prop_converted(prop_key, default)
+            else:
+                return get_prop_value(prop_key, "value", default)
+
+        # Debug logging for key sensors (optioneel)
+        test_keys = ["gallons_used_today", "total_outlet_water_gals", "treated_water_avail_gals", 
+                     "current_water_flow_gpm", "avg_salt_per_regen_lbs"]
+        for key in test_keys:
+            metric_val = get_prop_converted(key)
+            imperial_val = get_prop_value(key)
+            chosen_val = get_measurement(key)
+            _LOGGER.debug("Key %s: metric=%s, imperial=%s, chosen=%s", key, metric_val, imperial_val, chosen_val)
+
+        data = {
             "last_update": dt_util.now(),
             "salt_level_percent": wt.get("salt_level_percent"),
             "salt_level_rounded": wt.get("salt_level", {}).get("salt_level_percent_rounded"),
             "out_of_salt_days": get_prop_value("out_of_salt_estimate_days"),
             "low_salt_trip_days": get_prop_value("low_salt_trip_level_days"),
             "service_reminder": wts.get("service_reminder_message"),
-            "water_used_today": get_prop_converted("gallons_used_today"),
-            "total_water_used": wt.get("total_water_used", {}).get("value"),
-            "water_available": wt.get("treated_water_available", {}).get("value"),
-            "current_flow": get_prop_converted("current_water_flow_gpm"),
-            "avg_daily_use": get_prop_converted("avg_daily_use_gals"),
+
+            # Unit-dependent fields
+            "water_used_today": get_measurement("gallons_used_today"),
+            "total_water_used": get_measurement("total_outlet_water_gals"),
+            "water_available": get_measurement("treated_water_avail_gals"),
+            "current_flow": get_measurement("current_water_flow_gpm"),
+            "avg_daily_use": get_measurement("avg_daily_use_gals"),
+            "avg_salt_per_regen": get_measurement("avg_salt_per_regen_lbs"),
+
+            # Other fields
             "hardness": get_prop_value("hardness_grains"),
             "total_regens": get_prop_value("total_regens"),
             "manual_regens": get_prop_value("manual_regens"),
             "days_since_regen": wt.get("days_since_last_recharge") or get_prop_value("days_since_last_regen"),
             "avg_days_between_regens": get_prop_value("avg_days_between_regens"),
-            "avg_salt_per_regen": get_prop_converted("avg_salt_per_regen_lbs"),
             "model": wt.get("model") or get_prop_value("model_description"),
             "serial": device.get("serial_number"),
             "software_version": get_prop_value("base_software_version"),
@@ -154,7 +183,32 @@ class EcowaterCoordinator(DataUpdateCoordinator):
             "salt_alert": wts.get("salt_level_alert", False),
             "leak_alert": wts.get("flow_monitor_alert", False),
             "error_alert": wts.get("error_code_alert", False),
+            "alarm_beeping": get_prop_value("alarm_is_beeping", default=False),
         }
+
+        # Rock removed since last regen: sla beide eenheden op
+        rock_metric = get_prop_converted("rock_removed_since_rech_lbs")
+        rock_imperial = get_prop_value("rock_removed_since_rech_lbs")
+        data["rock_removed_since_regen"] = rock_metric if self.unit_system == UNIT_METRIC else rock_imperial
+        data["rock_removed_since_regen_metric"] = rock_metric
+        data["rock_removed_since_regen_imperial"] = rock_imperial
+
+        # Total rock removed: sla beide eenheden op
+        total_rock_metric = get_prop_converted("total_rock_removed_lbs")
+        total_rock_imperial = get_prop_value("total_rock_removed_lbs")
+        data["total_rock_removed"] = total_rock_metric if self.unit_system == UNIT_METRIC else total_rock_imperial
+        data["total_rock_removed_metric"] = total_rock_metric
+        data["total_rock_removed_imperial"] = total_rock_imperial
+
+        # Total salt use: sla beide eenheden op
+        total_salt_metric = get_prop_converted("total_salt_use_lbs")
+        total_salt_imperial = get_prop_value("total_salt_use_lbs")
+        data["total_salt_use"] = total_salt_metric if self.unit_system == UNIT_METRIC else total_salt_imperial
+        data["total_salt_use_metric"] = total_salt_metric
+        data["total_salt_use_imperial"] = total_salt_imperial
+
+        _LOGGER.debug("Data assembled (unit system: %s)", self.unit_system)
+        return data
 
     async def _fetch_data(self):
         """Internal data fetching. Uses wake-up + detail if device ID known, else falls back to device list."""
@@ -168,14 +222,12 @@ class EcowaterCoordinator(DataUpdateCoordinator):
         headers["Authorization"] = f"Bearer {self.token}"
 
         try:
-            # If we don't have a device ID yet, fetch the device list and extract ID + data
             if self.device_id is None:
                 device = await self._fetch_device_list(headers)
                 self.device_id = device.get("id")
                 _LOGGER.debug("Device ID obtained: %s", self.device_id)
                 return await self._parse_device_data(device)
 
-            # Device ID known: first send wake-up call to /live, then fetch fresh data from /detail-or-summary
             try:
                 live_url = f"{self.base_url}/devices/{self.device_id}/live"
                 await self._async_request("GET", live_url, headers=headers)
@@ -183,14 +235,12 @@ class EcowaterCoordinator(DataUpdateCoordinator):
             except Exception as wake_err:
                 _LOGGER.warning("Wake-up call failed, continuing with data fetch: %s", wake_err)
 
-            # Fetch current data from detail-or-summary
             detail_url = f"{self.base_url}/devices/{self.device_id}/detail-or-summary"
             response = await self._async_request("GET", detail_url, headers=headers)
             response.raise_for_status()
             json_data = await response.json()
             _LOGGER.debug("Detail data received for device %s", self.device_id)
 
-            # Extract the device object from the response
             device = json_data.get("device")
             if not device:
                 raise UpdateFailed("No device data found in detail response")

--- a/custom_components/ecowater_hydrolink_custom/manifest.json
+++ b/custom_components/ecowater_hydrolink_custom/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ecowater_hydrolink_custom",
   "name": "Ecowater Hydrolink Custom",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "documentation": "https://github.com/roeli1996/ha-ecowater-hydrolink",
   "issue_tracker": "https://github.com/roeli1996/ha-ecowater-hydrolink/issues",
   "dependencies": [],

--- a/custom_components/ecowater_hydrolink_custom/sensor.py
+++ b/custom_components/ecowater_hydrolink_custom/sensor.py
@@ -1,7 +1,7 @@
 import logging
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from .const import DOMAIN, CONF_USERNAME
+from .const import DOMAIN, UNIT_METRIC
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -11,47 +11,54 @@ async def async_setup_entry(hass, entry, async_add_entities):
     _LOGGER.debug("Setting up Ecowater sensors")
 
     entities = [
-        EcoWaterSensor(coordinator, "last_update", "last_update", None, SensorDeviceClass.TIMESTAMP, None),
-        EcoWaterSensor(coordinator, "salt_level_percent", "salt_level_percent", "%", None, SensorStateClass.MEASUREMENT),
-        EcoWaterSensor(coordinator, "salt_level_rounded", "salt_level_rounded", "%", None, None),
-        EcoWaterSensor(coordinator, "out_of_salt_days", "out_of_salt_days", "dagen", None, None),
-        EcoWaterSensor(coordinator, "low_salt_trip_days", "low_salt_trip_days", "dagen", None, None),
-        EcoWaterSensor(coordinator, "service_reminder", "service_reminder", None, None, None),
-        EcoWaterSensor(coordinator, "water_used_today", "water_used_today", "L", SensorDeviceClass.WATER, SensorStateClass.TOTAL_INCREASING),
-        EcoWaterSensor(coordinator, "total_water_used", "total_water_used", "L", SensorDeviceClass.WATER, SensorStateClass.TOTAL_INCREASING),
-        EcoWaterSensor(coordinator, "water_available", "water_available", "L", SensorDeviceClass.WATER, None),
-        EcoWaterSensor(coordinator, "current_flow", "current_flow", "L/min", None, SensorStateClass.MEASUREMENT),
-        EcoWaterSensor(coordinator, "avg_daily_use", "avg_daily_use", "L", SensorDeviceClass.WATER, None),
-        EcoWaterSensor(coordinator, "hardness", "hardness", "gpg", None, None),
-        EcoWaterSensor(coordinator, "total_regens", "total_regens", "keer", None, SensorStateClass.TOTAL_INCREASING),
-        EcoWaterSensor(coordinator, "manual_regens", "manual_regens", "keer", None, None),
-        EcoWaterSensor(coordinator, "days_since_regen", "days_since_regen", "dagen", None, None),
-        EcoWaterSensor(coordinator, "avg_days_between_regens", "avg_days_between_regens", "dagen", None, None),
-        EcoWaterSensor(coordinator, "avg_salt_per_regen", "avg_salt_per_regen", "kg", None, None),
-        EcoWaterSensor(coordinator, "model", "model", None, None, None),
-        EcoWaterSensor(coordinator, "serial", "serial", None, None, None),
-        EcoWaterSensor(coordinator, "software_version", "software_version", None, None, None),
-        EcoWaterSensor(coordinator, "rssi", "rssi", "dBm", SensorDeviceClass.SIGNAL_STRENGTH, SensorStateClass.MEASUREMENT),
-        EcoWaterSensor(coordinator, "wifi_ssid", "wifi_ssid", None, None, None),
-        EcoWaterSensor(coordinator, "days_in_operation", "days_in_operation", "dagen", None, SensorStateClass.TOTAL_INCREASING),
-        EcoWaterSensor(coordinator, "power_outages", "power_outages", "keer", None, SensorStateClass.TOTAL_INCREASING),
-        EcoWaterSensor(coordinator, "dealer_name", "dealer_name", None, None, None),
-        EcoWaterSensor(coordinator, "dealer_phone", "dealer_phone", None, None, None),
+        EcoWaterSensor(coordinator, "last_update", "last_update", None, None, SensorDeviceClass.TIMESTAMP, None),
+        EcoWaterSensor(coordinator, "salt_level_percent", "salt_level_percent", None, None, None, SensorStateClass.MEASUREMENT),
+        EcoWaterSensor(coordinator, "salt_level_rounded", "salt_level_rounded", None, None, None, None),
+        EcoWaterSensor(coordinator, "out_of_salt_days", "out_of_salt_days", "dagen", "dagen", None, None),
+        EcoWaterSensor(coordinator, "low_salt_trip_days", "low_salt_trip_days", "dagen", "dagen", None, None),
+        EcoWaterSensor(coordinator, "service_reminder", "service_reminder", None, None, None, None),
+        EcoWaterSensor(coordinator, "water_used_today", "water_used_today", "L", "gal", SensorDeviceClass.WATER, SensorStateClass.TOTAL_INCREASING),
+        EcoWaterSensor(coordinator, "total_water_used", "total_water_used", "L", "gal", SensorDeviceClass.WATER, SensorStateClass.TOTAL_INCREASING),
+        EcoWaterSensor(coordinator, "water_available", "water_available", "L", "gal", SensorDeviceClass.WATER, None),
+        EcoWaterSensor(coordinator, "current_flow", "current_flow", "L/min", "gpm", None, SensorStateClass.MEASUREMENT),
+        EcoWaterSensor(coordinator, "avg_daily_use", "avg_daily_use", "L", "gal", SensorDeviceClass.WATER, None),
+        EcoWaterSensor(coordinator, "hardness", "hardness", "gpg", "gpg", None, None),
+        EcoWaterSensor(coordinator, "total_regens", "total_regens", "keer", "keer", None, SensorStateClass.TOTAL_INCREASING),
+        EcoWaterSensor(coordinator, "manual_regens", "manual_regens", None, None, None, None),
+        EcoWaterSensor(coordinator, "days_since_regen", "days_since_regen", "dagen", "dagen", None, None),
+        EcoWaterSensor(coordinator, "avg_days_between_regens", "avg_days_between_regens", "dagen", "dagen", None, None),
+        EcoWaterSensor(coordinator, "avg_salt_per_regen", "avg_salt_per_regen", "kg", "lbs", None, None),
+        EcoWaterSensor(coordinator, "model", "model", None, None, None, None),
+        EcoWaterSensor(coordinator, "serial", "serial", None, None, None, None),
+        EcoWaterSensor(coordinator, "software_version", "software_version", None, None, None, None),
+        EcoWaterSensor(coordinator, "rssi", "rssi", "dBm", "dBm", SensorDeviceClass.SIGNAL_STRENGTH, SensorStateClass.MEASUREMENT),
+        EcoWaterSensor(coordinator, "wifi_ssid", "wifi_ssid", None, None, None, None),
+        EcoWaterSensor(coordinator, "days_in_operation", "days_in_operation", "dagen", "dagen", None, SensorStateClass.TOTAL_INCREASING),
+        EcoWaterSensor(coordinator, "power_outages", "power_outages", "keer", "keer", None, SensorStateClass.TOTAL_INCREASING),
+        EcoWaterSensor(coordinator, "dealer_name", "dealer_name", None, None, None, None),
+        EcoWaterSensor(coordinator, "dealer_phone", "dealer_phone", None, None, None, None),
+        # Nieuwe sensoren (eerder toegevoegd)
+        EcoWaterSensor(coordinator, "rock_removed_since_regen", "rock_removed_since_regen", "kg", "lbs", None, None),
+        # Extra nieuwe sensoren
+        EcoWaterSensor(coordinator, "total_rock_removed", "total_rock_removed", "kg", "lbs", None, SensorStateClass.TOTAL_INCREASING),
+        EcoWaterSensor(coordinator, "total_salt_use", "total_salt_use", "kg", "lbs", None, SensorStateClass.TOTAL_INCREASING),
     ]
 
     _LOGGER.debug("Aantal sensors om toe te voegen: %d", len(entities))
     async_add_entities(entities)
     _LOGGER.debug("Sensors toegevoegd aan Home Assistant")
 
+
 class EcoWaterSensor(CoordinatorEntity, SensorEntity):
     """Vertegenwoordigt een Ecowater sensor."""
 
-    def __init__(self, coordinator, trans_key, data_key, unit, device_class, state_class):
+    def __init__(self, coordinator, trans_key, data_key, unit_metric, unit_imperial, device_class, state_class):
         super().__init__(coordinator)
         self._attr_translation_key = trans_key
         self._attr_has_entity_name = True
         self._key = data_key
-        self._attr_native_unit_of_measurement = unit
+        self._unit_metric = unit_metric
+        self._unit_imperial = unit_imperial
         self._attr_device_class = device_class
         self._attr_state_class = state_class
         self._attr_unique_id = f"{DOMAIN}_{data_key}_{coordinator.entry.entry_id}"
@@ -71,3 +78,49 @@ class EcoWaterSensor(CoordinatorEntity, SensorEntity):
             return value
         _LOGGER.debug("Sensor %s: coordinator.data is None", self.entity_id)
         return None
+
+    @property
+    def native_unit_of_measurement(self):
+        """Bepaal de eenheid op basis van het gekozen eenheidssysteem."""
+        if self._unit_metric is None:
+            return None
+        if self.coordinator.unit_system == UNIT_METRIC:
+            unit = self._unit_metric
+        else:
+            unit = self._unit_imperial
+        _LOGGER.debug(
+            "Sensor %s: unit_system=%s, _unit_metric=%s, _unit_imperial=%s, eenheid=%s",
+            self.entity_id,
+            self.coordinator.unit_system,
+            self._unit_metric,
+            self._unit_imperial,
+            unit
+        )
+        return unit
+
+    @property
+    def extra_state_attributes(self):
+        """Voeg de waarde in de alternatieve eenheid toe als attribuut (indien beschikbaar)."""
+        attrs = {}
+        if not self.coordinator.data:
+            return attrs
+
+        # Helper om alternatieve eenheid toe te voegen
+        def add_alternate(key_metric, key_imperial, unit_metric, unit_imperial):
+            metric = self.coordinator.data.get(key_metric)
+            imperial = self.coordinator.data.get(key_imperial)
+            if self.coordinator.unit_system == UNIT_METRIC:
+                attrs["imperial_value"] = imperial
+                attrs["imperial_unit"] = unit_imperial
+            else:
+                attrs["metric_value"] = metric
+                attrs["metric_unit"] = unit_metric
+
+        if self._key == "rock_removed_since_regen":
+            add_alternate("rock_removed_since_regen_metric", "rock_removed_since_regen_imperial", "kg", "lbs")
+        elif self._key == "total_rock_removed":
+            add_alternate("total_rock_removed_metric", "total_rock_removed_imperial", "kg", "lbs")
+        elif self._key == "total_salt_use":
+            add_alternate("total_salt_use_metric", "total_salt_use_imperial", "kg", "lbs")
+
+        return attrs

--- a/custom_components/ecowater_hydrolink_custom/strings.json
+++ b/custom_components/ecowater_hydrolink_custom/strings.json
@@ -8,6 +8,7 @@
           "username": "Username (Email)",
           "password": "Password",
           "region": "Region",
+          "unit_system": "Unit system",
           "scan_interval_minutes": "Update interval (minutes)"
         }
       }
@@ -25,8 +26,9 @@
     "step": {
       "init": {
         "title": "Settings",
-        "description": "Adjust the data update frequency.",
+        "description": "Adjust the data update frequency and unit system.",
         "data": {
+          "unit_system": "Unit system",
           "scan_interval_minutes": "Update interval (minutes)"
         }
       }
@@ -59,14 +61,15 @@
       "days_in_operation": { "name": "Days in operation" },
       "power_outages": { "name": "Power outage count" },
       "dealer_name": { "name": "Dealer name" },
-      "dealer_phone": { "name": "Dealer phone" }
+      "dealer_phone": { "name": "Dealer phone" },
+      "rock_removed_since_regen": { "name": "Rock removed since last regeneration" }
     },
     "binary_sensor": {
       "is_regenerating": { "name": "Regeneration status" },
       "salt_alert": { "name": "Salt alert" },
       "leak_alert": { "name": "Leak alert" },
-      "conn_alert": { "name": "Connection alert" },
-      "error_alert": { "name": "System error alert" }
+      "error_alert": { "name": "System error alert" },
+      "alarm_beeping": { "name": "Alarm beeping" }
     }
   }
 }

--- a/custom_components/ecowater_hydrolink_custom/translations/de.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/de.json
@@ -1,0 +1,77 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Ecowater Hydrolink Custom",
+        "description": "Geben Sie Ihre Hydrolink Plus Anmeldedaten ein, um eine Verbindung zu Ihrem Wasserenthärter herzustellen.",
+        "data": {
+          "username": "Benutzername (E-Mail)",
+          "password": "Passwort",
+          "region": "Region",
+          "unit_system": "Einheitensystem",
+          "scan_interval_minutes": "Aktualisierungsintervall (Minuten)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Verbindung zur Hydrolink-API fehlgeschlagen.",
+      "invalid_auth": "Ungültiger Benutzername oder Passwort.",
+      "unknown": "Ein unerwarteter Fehler ist aufgetreten."
+    },
+    "abort": {
+      "already_configured": "Dieses Konto ist bereits konfiguriert."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Einstellungen",
+        "description": "Passen Sie die Aktualisierungshäufigkeit und das Einheitensystem an.",
+        "data": {
+          "unit_system": "Einheitensystem",
+          "scan_interval_minutes": "Aktualisierungsintervall (Minuten)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "last_update": { "name": "Letzte Aktualisierung" },
+      "salt_level_percent": { "name": "Salzgehalt" },
+      "salt_level_rounded": { "name": "Salzgehalt gerundet" },
+      "out_of_salt_days": { "name": "Tage bis Salz leer" },
+      "low_salt_trip_days": { "name": "Salzalarmschwelle" },
+      "service_reminder": { "name": "Serviceerinnerung" },
+      "water_used_today": { "name": "Wasserverbrauch heute" },
+      "total_water_used": { "name": "Gesamtwasserverbrauch" },
+      "water_available": { "name": "Verfügbares Weichwasser" },
+      "current_flow": { "name": "Aktuelle Durchflussrate" },
+      "avg_daily_use": { "name": "Durchschnittlicher täglicher Verbrauch" },
+      "hardness": { "name": "Härte" },
+      "total_regens": { "name": "Gesamtzahl der Regenerationen" },
+      "manual_regens": { "name": "Manuelle Regenerationen" },
+      "days_since_regen": { "name": "Tage seit letzter Regeneration" },
+      "avg_days_between_regens": { "name": "Durchschnittliche Tage zwischen Regenerationen" },
+      "avg_salt_per_regen": { "name": "Durchschnittlicher Salzverbrauch pro Regeneration" },
+      "model": { "name": "Modell" },
+      "serial": { "name": "Seriennummer" },
+      "software_version": { "name": "Softwareversion" },
+      "rssi": { "name": "Wi-Fi-Signalstärke" },
+      "wifi_ssid": { "name": "Wi-Fi-Netzwerk" },
+      "days_in_operation": { "name": "Betriebstage" },
+      "power_outages": { "name": "Anzahl der Stromausfälle" },
+      "dealer_name": { "name": "Händlername" },
+      "dealer_phone": { "name": "Händlertelefon" },
+      "rock_removed_since_regen": { "name": "Entfernte Härte seit letzter Regeneration" },
+      "total_rock_removed": { "name": "Gesamte entfernte Härte" },
+      "total_salt_use": { "name": "Gesamtsalzverbrauch" }
+    },
+    "binary_sensor": {
+      "is_regenerating": { "name": "Regenerationsstatus" },
+      "salt_alert": { "name": "Salzalarm" },
+      "leak_alert": { "name": "Leckagealarm" },
+      "error_alert": { "name": "Systemfehleralarm" },
+      "alarm_beeping": { "name": "Alarmsummer" }
+    }
+  }
+}

--- a/custom_components/ecowater_hydrolink_custom/translations/en.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/en.json
@@ -8,6 +8,7 @@
           "username": "Username (Email)",
           "password": "Password",
           "region": "Region",
+          "unit_system": "Unit system",
           "scan_interval_minutes": "Update interval (minutes)"
         }
       }
@@ -25,8 +26,9 @@
     "step": {
       "init": {
         "title": "Settings",
-        "description": "Adjust the data update frequency.",
+        "description": "Adjust the data update frequency and unit system.",
         "data": {
+          "unit_system": "Unit system",
           "scan_interval_minutes": "Update interval (minutes)"
         }
       }
@@ -59,14 +61,17 @@
       "days_in_operation": { "name": "Days in operation" },
       "power_outages": { "name": "Power outage count" },
       "dealer_name": { "name": "Dealer name" },
-      "dealer_phone": { "name": "Dealer phone" }
+      "dealer_phone": { "name": "Dealer phone" },
+      "rock_removed_since_regen": { "name": "Rock removed since last regeneration" },
+      "total_rock_removed": { "name": "Total rock removed" },
+      "total_salt_use": { "name": "Total salt used" }
     },
     "binary_sensor": {
       "is_regenerating": { "name": "Regeneration status" },
       "salt_alert": { "name": "Salt alert" },
       "leak_alert": { "name": "Leak alert" },
-      "conn_alert": { "name": "Connection alert" },
-      "error_alert": { "name": "System error alert" }
+      "error_alert": { "name": "System error alert" },
+      "alarm_beeping": { "name": "Alarm beeping" }
     }
   }
 }

--- a/custom_components/ecowater_hydrolink_custom/translations/es.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/es.json
@@ -1,0 +1,77 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Ecowater Hydrolink Custom",
+        "description": "Introduce tus credenciales de Hydrolink Plus para conectar tu descalcificador de agua.",
+        "data": {
+          "username": "Nombre de usuario (Email)",
+          "password": "Contraseña",
+          "region": "Región",
+          "unit_system": "Sistema de unidades",
+          "scan_interval_minutes": "Intervalo de actualización (minutos)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "No se pudo conectar con la API de Hydrolink.",
+      "invalid_auth": "Nombre de usuario o contraseña inválidos.",
+      "unknown": "Ocurrió un error inesperado."
+    },
+    "abort": {
+      "already_configured": "Esta cuenta ya está configurada."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Ajustes",
+        "description": "Ajusta la frecuencia de actualización y el sistema de unidades.",
+        "data": {
+          "unit_system": "Sistema de unidades",
+          "scan_interval_minutes": "Intervalo de actualización (minutos)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "last_update": { "name": "Última actualización" },
+      "salt_level_percent": { "name": "Nivel de sal" },
+      "salt_level_rounded": { "name": "Nivel de sal redondeado" },
+      "out_of_salt_days": { "name": "Días hasta agotar la sal" },
+      "low_salt_trip_days": { "name": "Umbral de alarma de sal" },
+      "service_reminder": { "name": "Recordatorio de servicio" },
+      "water_used_today": { "name": "Consumo de agua hoy" },
+      "total_water_used": { "name": "Consumo total de agua" },
+      "water_available": { "name": "Agua tratada disponible" },
+      "current_flow": { "name": "Caudal actual" },
+      "avg_daily_use": { "name": "Consumo diario medio" },
+      "hardness": { "name": "Dureza" },
+      "total_regens": { "name": "Número total de regeneraciones" },
+      "manual_regens": { "name": "Regeneraciones manuales" },
+      "days_since_regen": { "name": "Días desde última regeneración" },
+      "avg_days_between_regens": { "name": "Días promedio entre regeneraciones" },
+      "avg_salt_per_regen": { "name": "Consumo medio de sal por regeneración" },
+      "model": { "name": "Modelo" },
+      "serial": { "name": "Número de serie" },
+      "software_version": { "name": "Versión de software" },
+      "rssi": { "name": "Potencia de señal Wi-Fi" },
+      "wifi_ssid": { "name": "Red Wi-Fi" },
+      "days_in_operation": { "name": "Días en funcionamiento" },
+      "power_outages": { "name": "Número de cortes de energía" },
+      "dealer_name": { "name": "Nombre del distribuidor" },
+      "dealer_phone": { "name": "Teléfono del distribuidor" },
+      "rock_removed_since_regen": { "name": "Dureza eliminada desde última regeneración" },
+      "total_rock_removed": { "name": "Dureza total eliminada" },
+      "total_salt_use": { "name": "Consumo total de sal" }
+    },
+    "binary_sensor": {
+      "is_regenerating": { "name": "Estado de regeneración" },
+      "salt_alert": { "name": "Alarma de sal" },
+      "leak_alert": { "name": "Alarma de fuga" },
+      "error_alert": { "name": "Alarma de error del sistema" },
+      "alarm_beeping": { "name": "Zumbador de alarma" }
+    }
+  }
+}

--- a/custom_components/ecowater_hydrolink_custom/translations/fr.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/fr.json
@@ -1,0 +1,77 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Ecowater Hydrolink Custom",
+        "description": "Saisissez vos identifiants Hydrolink Plus pour connecter votre adoucisseur d'eau.",
+        "data": {
+          "username": "Nom d'utilisateur (Email)",
+          "password": "Mot de passe",
+          "region": "Région",
+          "unit_system": "Système d'unités",
+          "scan_interval_minutes": "Intervalle de mise à jour (minutes)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Échec de la connexion à l'API Hydrolink.",
+      "invalid_auth": "Nom d'utilisateur ou mot de passe invalide.",
+      "unknown": "Une erreur inattendue s'est produite."
+    },
+    "abort": {
+      "already_configured": "Ce compte est déjà configuré."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Paramètres",
+        "description": "Ajustez la fréquence de mise à jour et le système d'unités.",
+        "data": {
+          "unit_system": "Système d'unités",
+          "scan_interval_minutes": "Intervalle de mise à jour (minutes)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "last_update": { "name": "Dernière mise à jour" },
+      "salt_level_percent": { "name": "Niveau de sel" },
+      "salt_level_rounded": { "name": "Niveau de sel arrondi" },
+      "out_of_salt_days": { "name": "Jours avant épuisement du sel" },
+      "low_salt_trip_days": { "name": "Seuil d'alarme sel" },
+      "service_reminder": { "name": "Rappel d'entretien" },
+      "water_used_today": { "name": "Consommation d'eau aujourd'hui" },
+      "total_water_used": { "name": "Consommation d'eau totale" },
+      "water_available": { "name": "Eau adoucie disponible" },
+      "current_flow": { "name": "Débit actuel" },
+      "avg_daily_use": { "name": "Consommation quotidienne moyenne" },
+      "hardness": { "name": "Dureté" },
+      "total_regens": { "name": "Nombre total de régénérations" },
+      "manual_regens": { "name": "Régénérations manuelles" },
+      "days_since_regen": { "name": "Jours depuis la dernière régénération" },
+      "avg_days_between_regens": { "name": "Jours moyens entre régénérations" },
+      "avg_salt_per_regen": { "name": "Consommation moyenne de sel par régénération" },
+      "model": { "name": "Modèle" },
+      "serial": { "name": "Numéro de série" },
+      "software_version": { "name": "Version logicielle" },
+      "rssi": { "name": "Puissance du signal Wi-Fi" },
+      "wifi_ssid": { "name": "Réseau Wi-Fi" },
+      "days_in_operation": { "name": "Jours de fonctionnement" },
+      "power_outages": { "name": "Nombre de coupures de courant" },
+      "dealer_name": { "name": "Nom du revendeur" },
+      "dealer_phone": { "name": "Téléphone du revendeur" },
+      "rock_removed_since_regen": { "name": "Dureté éliminée depuis la dernière régénération" },
+      "total_rock_removed": { "name": "Dureté totale éliminée" },
+      "total_salt_use": { "name": "Consommation totale de sel" }
+    },
+    "binary_sensor": {
+      "is_regenerating": { "name": "État de régénération" },
+      "salt_alert": { "name": "Alarme sel" },
+      "leak_alert": { "name": "Alarme fuite" },
+      "error_alert": { "name": "Alarme erreur système" },
+      "alarm_beeping": { "name": "Avertisseur sonore" }
+    }
+  }
+}

--- a/custom_components/ecowater_hydrolink_custom/translations/it.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/it.json
@@ -1,0 +1,77 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Ecowater Hydrolink Custom",
+        "description": "Inserisci le tue credenziali Hydrolink Plus per connettere il tuo addolcitore d'acqua.",
+        "data": {
+          "username": "Nome utente (Email)",
+          "password": "Password",
+          "region": "Regione",
+          "unit_system": "Sistema di unità",
+          "scan_interval_minutes": "Intervallo di aggiornamento (minuti)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Impossibile connettersi all'API Hydrolink.",
+      "invalid_auth": "Nome utente o password non validi.",
+      "unknown": "Si è verificato un errore imprevisto."
+    },
+    "abort": {
+      "already_configured": "Questo account è già configurato."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Impostazioni",
+        "description": "Regola la frequenza di aggiornamento e il sistema di unità.",
+        "data": {
+          "unit_system": "Sistema di unità",
+          "scan_interval_minutes": "Intervallo di aggiornamento (minuti)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "last_update": { "name": "Ultimo aggiornamento" },
+      "salt_level_percent": { "name": "Livello di sale" },
+      "salt_level_rounded": { "name": "Livello di sale arrotondato" },
+      "out_of_salt_days": { "name": "Giorni prima di esaurire il sale" },
+      "low_salt_trip_days": { "name": "Soglia allarme sale" },
+      "service_reminder": { "name": "Promemoria manutenzione" },
+      "water_used_today": { "name": "Consumo d'acqua oggi" },
+      "total_water_used": { "name": "Consumo d'acqua totale" },
+      "water_available": { "name": "Acqua trattata disponibile" },
+      "current_flow": { "name": "Flusso attuale" },
+      "avg_daily_use": { "name": "Consumo medio giornaliero" },
+      "hardness": { "name": "Durezza" },
+      "total_regens": { "name": "Numero totale di rigenerazioni" },
+      "manual_regens": { "name": "Rigenerazioni manuali" },
+      "days_since_regen": { "name": "Giorni dall'ultima rigenerazione" },
+      "avg_days_between_regens": { "name": "Giorni medi tra rigenerazioni" },
+      "avg_salt_per_regen": { "name": "Consumo medio di sale per rigenerazione" },
+      "model": { "name": "Modello" },
+      "serial": { "name": "Numero di serie" },
+      "software_version": { "name": "Versione software" },
+      "rssi": { "name": "Potenza segnale Wi-Fi" },
+      "wifi_ssid": { "name": "Rete Wi-Fi" },
+      "days_in_operation": { "name": "Giorni di funzionamento" },
+      "power_outages": { "name": "Numero di interruzioni di corrente" },
+      "dealer_name": { "name": "Nome rivenditore" },
+      "dealer_phone": { "name": "Telefono rivenditore" },
+      "rock_removed_since_regen": { "name": "Durezza rimossa dall'ultima rigenerazione" },
+      "total_rock_removed": { "name": "Durezza totale rimossa" },
+      "total_salt_use": { "name": "Consumo totale di sale" }
+    },
+    "binary_sensor": {
+      "is_regenerating": { "name": "Stato rigenerazione" },
+      "salt_alert": { "name": "Allarme sale" },
+      "leak_alert": { "name": "Allarme perdita" },
+      "error_alert": { "name": "Allarme errore sistema" },
+      "alarm_beeping": { "name": "Cicalino allarme" }
+    }
+  }
+}

--- a/custom_components/ecowater_hydrolink_custom/translations/nl.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/nl.json
@@ -8,6 +8,7 @@
           "username": "Gebruikersnaam (Email)",
           "password": "Wachtwoord",
           "region": "Regio",
+          "unit_system": "Eenheidssysteem",
           "scan_interval_minutes": "Update interval (minuten)"
         }
       }
@@ -25,8 +26,9 @@
     "step": {
       "init": {
         "title": "Instellingen",
-        "description": "Pas de update-frequentie van de data aan.",
+        "description": "Pas de update-frequentie en het eenheidssysteem aan.",
         "data": {
+          "unit_system": "Eenheidssysteem",
           "scan_interval_minutes": "Update interval (minuten)"
         }
       }
@@ -59,14 +61,17 @@
       "days_in_operation": { "name": "Dagen in werking" },
       "power_outages": { "name": "Aantal stroomonderbrekingen" },
       "dealer_name": { "name": "Dealer naam" },
-      "dealer_phone": { "name": "Dealer telefoon" }
+      "dealer_phone": { "name": "Dealer telefoon" },
+      "rock_removed_since_regen": { "name": "Verwijderde hardheid sinds laatste spoeling" },
+      "total_rock_removed": { "name": "Totaal verwijderde hardheid" },
+      "total_salt_use": { "name": "Totaal zoutverbruik" }
     },
     "binary_sensor": {
       "is_regenerating": { "name": "Regeneratie status" },
       "salt_alert": { "name": "Zout alarm" },
       "leak_alert": { "name": "Lekkage alarm" },
-      "conn_alert": { "name": "Verbindings alarm" },
-      "error_alert": { "name": "Systeem fout alarm" }
+      "error_alert": { "name": "Systeem fout alarm" },
+      "alarm_beeping": { "name": "Alarm zoemer" }
     }
   }
 }

--- a/custom_components/ecowater_hydrolink_custom/translations/pl.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/pl.json
@@ -1,0 +1,77 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Ecowater Hydrolink Custom",
+        "description": "Wprowadź swoje dane logowania do Hydrolink Plus, aby połączyć się ze zmiękczaczem wody.",
+        "data": {
+          "username": "Nazwa użytkownika (Email)",
+          "password": "Hasło",
+          "region": "Region",
+          "unit_system": "System jednostek",
+          "scan_interval_minutes": "Interwał aktualizacji (minuty)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Nie można połączyć się z API Hydrolink.",
+      "invalid_auth": "Nieprawidłowa nazwa użytkownika lub hasło.",
+      "unknown": "Wystąpił nieoczekiwany błąd."
+    },
+    "abort": {
+      "already_configured": "To konto jest już skonfigurowane."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Ustawienia",
+        "description": "Dostosuj częstotliwość aktualizacji i system jednostek.",
+        "data": {
+          "unit_system": "System jednostek",
+          "scan_interval_minutes": "Interwał aktualizacji (minuty)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "last_update": { "name": "Ostatnia aktualizacja" },
+      "salt_level_percent": { "name": "Poziom soli" },
+      "salt_level_rounded": { "name": "Zaokrąglony poziom soli" },
+      "out_of_salt_days": { "name": "Dni do wyczerpania soli" },
+      "low_salt_trip_days": { "name": "Próg alarmu niskiego poziomu soli" },
+      "service_reminder": { "name": "Przypomnienie o serwisie" },
+      "water_used_today": { "name": "Zużycie wody dzisiaj" },
+      "total_water_used": { "name": "Całkowite zużycie wody" },
+      "water_available": { "name": "Dostępna miękka woda" },
+      "current_flow": { "name": "Bieżący przepływ" },
+      "avg_daily_use": { "name": "Średnie dzienne zużycie" },
+      "hardness": { "name": "Twardość" },
+      "total_regens": { "name": "Łączna liczba regeneracji" },
+      "manual_regens": { "name": "Regeneracje ręczne" },
+      "days_since_regen": { "name": "Dni od ostatniej regeneracji" },
+      "avg_days_between_regens": { "name": "Średnia dni między regeneracjami" },
+      "avg_salt_per_regen": { "name": "Średnie zużycie soli na regenerację" },
+      "model": { "name": "Model" },
+      "serial": { "name": "Numer seryjny" },
+      "software_version": { "name": "Wersja oprogramowania" },
+      "rssi": { "name": "Siła sygnału Wi-Fi" },
+      "wifi_ssid": { "name": "Sieć Wi-Fi" },
+      "days_in_operation": { "name": "Dni w eksploatacji" },
+      "power_outages": { "name": "Liczba awarii zasilania" },
+      "dealer_name": { "name": "Nazwa dealera" },
+      "dealer_phone": { "name": "Telefon dealera" },
+      "rock_removed_since_regen": { "name": "Usunięta twardość od ostatniej regeneracji" },
+      "total_rock_removed": { "name": "Całkowita usunięta twardość" },
+      "total_salt_use": { "name": "Całkowite zużycie soli" }
+    },
+    "binary_sensor": {
+      "is_regenerating": { "name": "Stan regeneracji" },
+      "salt_alert": { "name": "Alarm soli" },
+      "leak_alert": { "name": "Alarm wycieku" },
+      "error_alert": { "name": "Alarm błędu systemu" },
+      "alarm_beeping": { "name": "Sygnalizator dźwiękowy" }
+    }
+  }
+}

--- a/custom_components/ecowater_hydrolink_custom/translations/pt.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/pt.json
@@ -1,0 +1,77 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Ecowater Hydrolink Custom",
+        "description": "Introduza as suas credenciais Hydrolink Plus para ligar o seu descalcificador de água.",
+        "data": {
+          "username": "Nome de utilizador (Email)",
+          "password": "Palavra-passe",
+          "region": "Região",
+          "unit_system": "Sistema de unidades",
+          "scan_interval_minutes": "Intervalo de atualização (minutos)"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Falha na ligação à API Hydrolink.",
+      "invalid_auth": "Nome de utilizador ou palavra-passe inválidos.",
+      "unknown": "Ocorreu um erro inesperado."
+    },
+    "abort": {
+      "already_configured": "Esta conta já está configurada."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Definições",
+        "description": "Ajuste a frequência de atualização e o sistema de unidades.",
+        "data": {
+          "unit_system": "Sistema de unidades",
+          "scan_interval_minutes": "Intervalo de atualização (minutos)"
+        }
+      }
+    }
+  },
+  "entity": {
+    "sensor": {
+      "last_update": { "name": "Última atualização" },
+      "salt_level_percent": { "name": "Nível de sal" },
+      "salt_level_rounded": { "name": "Nível de sal arredondado" },
+      "out_of_salt_days": { "name": "Dias até o sal acabar" },
+      "low_salt_trip_days": { "name": "Limiar de alarme de sal baixo" },
+      "service_reminder": { "name": "Lembrete de manutenção" },
+      "water_used_today": { "name": "Consumo de água hoje" },
+      "total_water_used": { "name": "Consumo total de água" },
+      "water_available": { "name": "Água tratada disponível" },
+      "current_flow": { "name": "Caudal atual" },
+      "avg_daily_use": { "name": "Consumo médio diário" },
+      "hardness": { "name": "Dureza" },
+      "total_regens": { "name": "Número total de regenerações" },
+      "manual_regens": { "name": "Regenerações manuais" },
+      "days_since_regen": { "name": "Dias desde a última regeneração" },
+      "avg_days_between_regens": { "name": "Dias médios entre regenerações" },
+      "avg_salt_per_regen": { "name": "Consumo médio de sal por regeneração" },
+      "model": { "name": "Modelo" },
+      "serial": { "name": "Número de série" },
+      "software_version": { "name": "Versão do software" },
+      "rssi": { "name": "Potência do sinal Wi-Fi" },
+      "wifi_ssid": { "name": "Rede Wi-Fi" },
+      "days_in_operation": { "name": "Dias em funcionamento" },
+      "power_outages": { "name": "Número de falhas de energia" },
+      "dealer_name": { "name": "Nome do distribuidor" },
+      "dealer_phone": { "name": "Telefone do distribuidor" },
+      "rock_removed_since_regen": { "name": "Dureza removida desde a última regeneração" },
+      "total_rock_removed": { "name": "Dureza total removida" },
+      "total_salt_use": { "name": "Consumo total de sal" }
+    },
+    "binary_sensor": {
+      "is_regenerating": { "name": "Estado da regeneração" },
+      "salt_alert": { "name": "Alarme de sal" },
+      "leak_alert": { "name": "Alarme de fuga" },
+      "error_alert": { "name": "Alarme de erro do sistema" },
+      "alarm_beeping": { "name": "Sinal sonoro de alarme" }
+    }
+  }
+}


### PR DESCRIPTION
## v1.3.0 – Unit system, new sensors, and more!

This release adds **unit system selection** (metric/imperial) and several new sensors.  
You can now choose your preferred units during configuration or via options – the integration will automatically display the correct values. The alternative unit is available as an attribute on each sensor for advanced use.

**New sensors added:**
- `alarm_beeping` – binary sensor indicating if the audible alarm is active.
- `rock_removed_since_regen` – hardness removed since the last regeneration (kg/lbs).
- `total_rock_removed` – total hardness removed over the device's lifetime.
- `total_salt_use` – total salt consumed over the device's lifetime.

The options flow now also includes the unit system setting, so you can easily switch at any time.

> ⚠️ **Note for existing users:**  
> If the data doesn't change, you need to wait until a sensor is changing in value, see readme.

For full details, see the [changelog](https://github.com/roeli1996/ha-ecowater-hydrolink/releases/tag/v1.3.0).