### PR TITLE
 Experimental sensor for water usage during regeneration

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ The integration adds the following sensors (all grouped under one device). Units
 | `total_rock_removed` | Total hardness removed over lifetime | kg | | `imperial_value` / `metric_value` |
 | `total_salt_use` | Total salt consumed over lifetime | kg | | `imperial_value` / `metric_value` |
 | `calculated_daily_use` | Total calculated water use for today | L | water | `imperial_value` / `metric_value` |
-| `water_used_in_last_regen` | Water used during the last regeneration cycle | L | water | – |
+| `water_used_in_last_regen` | Water used during the last regeneration cycle (experimental – needs verification) | L | water | – |
 
-> **Note:** Attributes containing the alternative unit only appear after the sensor has received at least one update with the new unit setting. If you change the unit system, the attributes may be empty until the next data refresh. The `calculated_daily_use` resets to zero after each update. The `water_used_in_last_regen` sensor shows the water consumption during the most recent regeneration; it will be `0` until a regeneration has completed.
+> **Note:** Attributes containing the alternative unit only appear after the sensor has received at least one update with the new unit setting. If you change the unit system, the attributes may be empty until the next data refresh. The `calculated_daily_use` resets to zero after each update. The `water_used_in_last_regen` sensor is experimental and its accuracy depends on whether the device reports total water usage during regeneration (this has not yet been confirmed). It will display `0` until a regeneration cycle has completed after updating.
 
 ## 🚨 Binary sensors
 
@@ -151,12 +151,13 @@ Some sensors, such as `rock_removed_since_regen`, `total_rock_removed`, and `tot
 
 ### Known limitations
 - Not tested on multiple devices under a single account.
+- The `water_used_in_last_regen` sensor is experimental; its accuracy is not guaranteed and depends on the device's update behavior during regeneration.
 
 ## 📝 Changelog
 
-### v1.3.4 – Added water usage during last regeneration sensor - 2026-06-19
+### v1.3.4 – Added water usage during last regeneration sensor (experimental) - 2026-06-19
 
-This release adds a new sensor that tracks the amount of water consumed during the most recent regeneration cycle.
+This release adds a new sensor that tracks the amount of water consumed during the most recent regeneration cycle. **Please note:** this feature is experimental and its accuracy depends on whether the device updates total water usage during regeneration – this has not yet been verified.
 
 #### ✨ New features
 - **`water_used_in_last_regen` sensor** – shows the water usage (in liters or gallons) during the last regeneration. The value is calculated by comparing the total water used at the start and end of a regeneration cycle.
@@ -165,6 +166,7 @@ This release adds a new sensor that tracks the amount of water consumed during t
 #### 📝 Notes
 - The new sensor will display `0` until a regeneration has occurred after updating.
 - Fully backward compatible; no configuration changes needed.
+- This sensor is experimental – please report any issues with its accuracy.
 
 ### v1.3.3 – Translating Dutch terms ('keer' and 'dagen') - 2026-03-02
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The integration adds the following sensors (all grouped under one device). Units
 | `water_used_today` | Water usage today | L | water | `imperial_value` / `metric_value` |
 | `total_water_used` | Total water usage since installation | L | water | `imperial_value` / `metric_value` |
 | `water_available` | Amount of treated water still available | L | water | `imperial_value` / `metric_value` |
-| `current_flow` | Current flow rate | L/min | | `imperial_value` / `metric_value` |
+| `current_flow` | Current flow rate | L/min | water | `imperial_value` / `metric_value` |
 | `avg_daily_use` | Average daily water usage | L | water | `imperial_value` / `metric_value` |
 | `hardness` | Water hardness setting | gpg | | – |
 | `total_regens` | Total number of regenerations | | | – |
@@ -116,9 +116,10 @@ The integration adds the following sensors (all grouped under one device). Units
 | `rock_removed_since_regen` | Hardness removed since last regeneration | kg | | `imperial_value` / `metric_value` |
 | `total_rock_removed` | Total hardness removed over lifetime | kg | | `imperial_value` / `metric_value` |
 | `total_salt_use` | Total salt consumed over lifetime | kg | | `imperial_value` / `metric_value` |
-| `calculated_daily_use` | Total calculated water use for today | L | Water | `imperial_value` / `metric_value` |
+| `calculated_daily_use` | Total calculated water use for today | L | water | `imperial_value` / `metric_value` |
+| `water_used_in_last_regen` | Water used during the last regeneration cycle | L | water | – |
 
-> **Note:** Attributes containing the alternative unit only appear after the sensor has received at least one update with the new unit setting. If you change the unit system, the attributes may be empty until the next data refresh. The calculated_daily_use resets to zero after each update.
+> **Note:** Attributes containing the alternative unit only appear after the sensor has received at least one update with the new unit setting. If you change the unit system, the attributes may be empty until the next data refresh. The `calculated_daily_use` resets to zero after each update. The `water_used_in_last_regen` sensor shows the water consumption during the most recent regeneration; it will be `0` until a regeneration has completed.
 
 ## 🚨 Binary sensors
 
@@ -152,6 +153,18 @@ Some sensors, such as `rock_removed_since_regen`, `total_rock_removed`, and `tot
 - Not tested on multiple devices under a single account.
 
 ## 📝 Changelog
+
+### v1.3.4 – Added water usage during last regeneration sensor - 2026-06-19
+
+This release adds a new sensor that tracks the amount of water consumed during the most recent regeneration cycle.
+
+#### ✨ New features
+- **`water_used_in_last_regen` sensor** – shows the water usage (in liters or gallons) during the last regeneration. The value is calculated by comparing the total water used at the start and end of a regeneration cycle.
+- **Added device class `water`** to the `current_flow` sensor for better icon and history representation.
+
+#### 📝 Notes
+- The new sensor will display `0` until a regeneration has occurred after updating.
+- Fully backward compatible; no configuration changes needed.
 
 ### v1.3.3 – Translating Dutch terms ('keer' and 'dagen') - 2026-03-02
 

--- a/custom_components/ecowater_hydrolink_custom/coordinator.py
+++ b/custom_components/ecowater_hydrolink_custom/coordinator.py
@@ -43,6 +43,7 @@ class EcowaterCoordinator(DataUpdateCoordinator):
     - Data retrieval from /detail-or-summary
     - Unit system and language awareness
     - Calculation of daily usage from total water used
+    - Calculation of water used in the last regeneration cycle
     """
 
     def __init__(self, hass, entry):
@@ -63,7 +64,6 @@ class EcowaterCoordinator(DataUpdateCoordinator):
         )
 
         # Store the Home Assistant language (first two letters) for unit translations
-        # This allows sensors to display e.g. "days" in English, "dagen" in Dutch, etc.
         self.language = hass.config.language[:2]
 
         _LOGGER.debug(
@@ -83,7 +83,12 @@ class EcowaterCoordinator(DataUpdateCoordinator):
         # Variables for calculated daily usage (derived from total_water_used)
         self._previous_total = None   # Last known total water value
         self._daily_total = 0.0       # Accumulated usage since midnight
-        self._last_date = None         # Date of the last update (used for reset)
+        self._last_date = None        # Date of the last update (used for reset)
+
+        # Variables for water used in the last regeneration
+        self._prev_regen = False           # Previous regeneration state (True/False)
+        self._water_at_regen_start = None  # Total water at start of regeneration
+        self._water_used_last_regen = 0.0  # Water used in the last regeneration cycle
 
         # Update interval (in minutes) – from options, falling back to data
         interval = entry.options.get(
@@ -329,6 +334,35 @@ class EcowaterCoordinator(DataUpdateCoordinator):
             data["calculated_daily_use"] = self._daily_total
         else:
             data["calculated_daily_use"] = 0
+
+        # ----- Water used in the last regeneration -----
+        # This calculates the amount of water consumed during the most recent regeneration cycle.
+        # It uses the transition of the 'is_regenerating' flag to capture total water at start and end.
+        current_regen = data.get("is_regenerating", False)
+        current_total_water = data.get("total_water_used")
+
+        if current_total_water is not None:
+            # Regeneration started: transition False -> True
+            if not self._prev_regen and current_regen:
+                self._water_at_regen_start = current_total_water
+                _LOGGER.debug("Regeneration started, water total at start: %s", self._water_at_regen_start)
+
+            # Regeneration ended: transition True -> False
+            elif self._prev_regen and not current_regen:
+                if self._water_at_regen_start is not None:
+                    self._water_used_last_regen = current_total_water - self._water_at_regen_start
+                    if self._water_used_last_regen < 0:
+                        self._water_used_last_regen = 0.0
+                    _LOGGER.debug("Regeneration ended, water used: %s", self._water_used_last_regen)
+                    self._water_at_regen_start = None
+                else:
+                    _LOGGER.warning("Regeneration ended but start value missing")
+
+            # Update previous state for next run
+            self._prev_regen = current_regen
+
+        # Store the calculated value (already in the current unit system)
+        data["water_used_in_last_regen"] = self._water_used_last_regen
 
         _LOGGER.debug("Data assembled (unit system: %s)", self.unit_system)
         return data

--- a/custom_components/ecowater_hydrolink_custom/manifest.json
+++ b/custom_components/ecowater_hydrolink_custom/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ecowater_hydrolink_custom",
   "name": "Ecowater Hydrolink Custom",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "documentation": "https://github.com/roeli1996/ha-ecowater-hydrolink",
   "issue_tracker": "https://github.com/roeli1996/ha-ecowater-hydrolink/issues",
   "dependencies": [],

--- a/custom_components/ecowater_hydrolink_custom/sensor.py
+++ b/custom_components/ecowater_hydrolink_custom/sensor.py
@@ -205,6 +205,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
             coordinator, "calculated_daily_use", "calculated_daily_use",
             "L", "gal", SensorDeviceClass.WATER, SensorStateClass.TOTAL_INCREASING
         ),
+        # NEW: Water used in the last regeneration cycle
+        EcoWaterSensor(
+            coordinator, "water_used_in_last_regen", "water_used_in_last_regen",
+            "L", "gal", SensorDeviceClass.WATER, None
+        ),
     ]
 
     _LOGGER.debug("Number of sensors to add: %d", len(entities))
@@ -253,6 +258,7 @@ class EcoWaterSensor(CoordinatorEntity, SensorEntity):
         "total_rock_removed": "mdi:weight",
         "total_salt_use": "mdi:weight",
         "calculated_daily_use": "mdi:calculator",
+        "water_used_in_last_regen": "mdi:water-sync",
     }
 
     def __init__(self, coordinator, trans_key, data_key, unit_metric, unit_imperial, device_class, state_class):

--- a/custom_components/ecowater_hydrolink_custom/sensor.py
+++ b/custom_components/ecowater_hydrolink_custom/sensor.py
@@ -120,7 +120,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         ),
         EcoWaterSensor(
             coordinator, "current_flow", "current_flow",
-            "L/min", "gpm", None, SensorStateClass.MEASUREMENT
+            "L/min", "gpm", SensorDeviceClass.WATER, SensorStateClass.MEASUREMENT
         ),
         EcoWaterSensor(
             coordinator, "avg_daily_use", "avg_daily_use",

--- a/custom_components/ecowater_hydrolink_custom/strings.json
+++ b/custom_components/ecowater_hydrolink_custom/strings.json
@@ -65,7 +65,8 @@
       "rock_removed_since_regen": { "name": "Rock removed since last regeneration" },
       "total_rock_removed": { "name": "Total rock removed" },
       "total_salt_use": { "name": "Total salt used" },
-      "calculated_daily_use": { "name": "Calculated daily usage" }
+      "calculated_daily_use": { "name": "Calculated daily usage" },
+      "water_used_in_last_regen": { "name": "Water used in last regeneration" }
     },
     "binary_sensor": {
       "is_regenerating": { "name": "Regeneration status" },

--- a/custom_components/ecowater_hydrolink_custom/translations/de.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/de.json
@@ -65,7 +65,8 @@
       "rock_removed_since_regen": { "name": "Entfernte Härte seit letzter Regeneration" },
       "total_rock_removed": { "name": "Gesamte entfernte Härte" },
       "total_salt_use": { "name": "Gesamtsalzverbrauch" },
-      "calculated_daily_use": { "name": "Berechneter Tagesverbrauch" }
+      "calculated_daily_use": { "name": "Berechneter Tagesverbrauch" },
+      "water_used_in_last_regen": { "name": "Wasserverbrauch während der letzten Regeneration" }
     },
     "binary_sensor": {
       "is_regenerating": { "name": "Regenerationsstatus" },

--- a/custom_components/ecowater_hydrolink_custom/translations/en.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/en.json
@@ -65,7 +65,8 @@
       "rock_removed_since_regen": { "name": "Rock removed since last regeneration" },
       "total_rock_removed": { "name": "Total rock removed" },
       "total_salt_use": { "name": "Total salt used" },
-      "calculated_daily_use": { "name": "Calculated daily usage" }
+      "calculated_daily_use": { "name": "Calculated daily usage" },
+      "water_used_in_last_regen": { "name": "Water used in last regeneration" }
     },
     "binary_sensor": {
       "is_regenerating": { "name": "Regeneration status" },

--- a/custom_components/ecowater_hydrolink_custom/translations/es.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/es.json
@@ -65,7 +65,8 @@
       "rock_removed_since_regen": { "name": "Dureza eliminada desde última regeneración" },
       "total_rock_removed": { "name": "Dureza total eliminada" },
       "total_salt_use": { "name": "Consumo total de sal" },
-      "calculated_daily_use": { "name": "Consumo diario calculado" }
+      "calculated_daily_use": { "name": "Consumo diario calculado" },
+      "water_used_in_last_regen": { "name": "Agua utilizada en la última regeneración" }
     },
     "binary_sensor": {
       "is_regenerating": { "name": "Estado de regeneración" },

--- a/custom_components/ecowater_hydrolink_custom/translations/fr.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/fr.json
@@ -65,7 +65,8 @@
       "rock_removed_since_regen": { "name": "Dureté éliminée depuis la dernière régénération" },
       "total_rock_removed": { "name": "Dureté totale éliminée" },
       "total_salt_use": { "name": "Consommation totale de sel" },
-      "calculated_daily_use": { "name": "Consommation quotidienne calculée" }
+      "calculated_daily_use": { "name": "Consommation quotidienne calculée" },
+      "water_used_in_last_regen": { "name": "Eau utilisée lors de la dernière régénération" }
     },
     "binary_sensor": {
       "is_regenerating": { "name": "État de régénération" },

--- a/custom_components/ecowater_hydrolink_custom/translations/it.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/it.json
@@ -65,7 +65,8 @@
       "rock_removed_since_regen": { "name": "Durezza rimossa dall'ultima rigenerazione" },
       "total_rock_removed": { "name": "Durezza totale rimossa" },
       "total_salt_use": { "name": "Consumo totale di sale" },
-      "calculated_daily_use": { "name": "Consumo giornaliero calcolato" }
+      "calculated_daily_use": { "name": "Consumo giornaliero calcolato" },
+      "water_used_in_last_regen": { "name": "Acqua utilizzata nell'ultima rigenerazione" }
     },
     "binary_sensor": {
       "is_regenerating": { "name": "Stato rigenerazione" },

--- a/custom_components/ecowater_hydrolink_custom/translations/nl.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/nl.json
@@ -65,7 +65,8 @@
       "rock_removed_since_regen": { "name": "Verwijderde hardheid sinds laatste spoeling" },
       "total_rock_removed": { "name": "Totaal verwijderde hardheid" },
       "total_salt_use": { "name": "Totaal zoutverbruik" },
-      "calculated_daily_use": { "name": "Berekend dagelijks verbruik" }
+      "calculated_daily_use": { "name": "Berekend dagelijks verbruik" },
+      "water_used_in_last_regen": { "name": "Waterverbruik tijdens laatste regeneratie" }
     },
     "binary_sensor": {
       "is_regenerating": { "name": "Regeneratie status" },

--- a/custom_components/ecowater_hydrolink_custom/translations/pl.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/pl.json
@@ -65,7 +65,8 @@
       "rock_removed_since_regen": { "name": "Usunięta twardość od ostatniej regeneracji" },
       "total_rock_removed": { "name": "Całkowita usunięta twardość" },
       "total_salt_use": { "name": "Całkowite zużycie soli" },
-      "calculated_daily_use": { "name": "Consumo giornaliero calcolato" }
+      "calculated_daily_use": { "name": "Obliczone dzienne zużycie" },
+      "water_used_in_last_regen": { "name": "Zużycie wody podczas ostatniej regeneracji" }
     },
     "binary_sensor": {
       "is_regenerating": { "name": "Stan regeneracji" },

--- a/custom_components/ecowater_hydrolink_custom/translations/pt.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/pt.json
@@ -65,7 +65,8 @@
       "rock_removed_since_regen": { "name": "Dureza removida desde a última regeneração" },
       "total_rock_removed": { "name": "Dureza total removida" },
       "total_salt_use": { "name": "Consumo total de sal" },
-      "calculated_daily_use": { "name": "Consumo diário calculado" }
+      "calculated_daily_use": { "name": "Consumo diário calculado" },
+      "water_used_in_last_regen": { "name": "Água utilizada na última regeneração" }
     },
     "binary_sensor": {
       "is_regenerating": { "name": "Estado da regeneração" },


### PR DESCRIPTION
## v1.3.4 – Experimental sensor for water usage during regeneration

This release adds a new experimental sensor and a small improvement to an existing sensor.

### ✨ New features
- **`water_used_in_last_regen` sensor** – attempts to show the amount of water (in liters or gallons) consumed during the most recent regeneration cycle. The value is calculated by comparing the total water used at the start and end of a regeneration.
  - **⚠️ Experimental:** Accuracy depends on whether the device updates total water usage during regeneration – this has not yet been confirmed. Please share your feedback!

### 🔧 Improvements
- **Device class `water`** added to the `current_flow` sensor for better icon and history representation.

### 📝 Notes
- The new sensor will display `0` until a regeneration has occurred after updating.
- Fully backward compatible; no configuration changes needed.