### PR TITLE
Add EcoWater iQua backend support (Aquahome Duo Smart and related devices)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,21 @@
 [![hacs][hacsbadge]][hacs]
 [![Author][author-shield]][github]
 
-**Home Assistant integration for Ecowater water softeners via the Hydrolink platform.**
+**Home Assistant integration for Ecowater water softeners, supporting both the Hydrolink platform and the iQua platform (e.g. Aquahome Duo Smart).**
 
-This custom integration retrieves real-time data from your Ecowater water softener through the Hydrolink API and displays it as sensors and binary sensors in Home Assistant. You can monitor water usage, salt level, regeneration status, alerts, and many other parameters. The API offers many more sensors; currently the most relevant ones have been added.
+This custom integration retrieves real-time data from your Ecowater water softener and displays it as sensors, binary sensors and (where supported) a switch in Home Assistant. You can monitor water usage, salt level, regeneration status, alerts, and many other parameters. The APIs offer many more sensors; currently the most relevant ones have been added.
 
-> **🌍 Multi-region support:** Starting from version 1.1.0, you can select your region during configuration:  
+> **🧩 Two cloud backends:** Starting from version 1.5.0, this integration supports two different EcoWater cloud platforms - pick the one that matches the app you use for your device:
+> - **Hydrolink** (`app.hydrolinkhome.eu` / `.com`) - the original "Hydrolink" app.
+> - **iQua** (`apioem.ecowater.com`) - used by the "iQua" app, which covers devices such as the **Aquahome Duo Smart**, and (untested, community feedback welcome) other iQua-family rebrands like Viessmann, North Star, Morton, Whirlpool, Rheem, GE and Kenmore softeners.
+>
+> You choose the backend as the first step of setting up the integration. See [⚙️ Configuration](#️-configuration) below.
+
+> **🌍 Multi-region support (Hydrolink only):** Starting from version 1.1.0, you can select your region during configuration:  
 > - **Europe** (`app.hydrolinkhome.eu`)  
 > - **US / Other** (`app.hydrolinkhome.com`)
 
-> **📏 Unit system selection:** Starting from version 1.3.0, you can choose between metric (liters, kg) and imperial (gallons, lbs) units during configuration or via options. The integration automatically displays the correct values based on your preference. The alternative unit is available as an attribute on each sensor (see below).
+> **📏 Unit system selection:** Starting from version 1.3.0, you can choose between metric (liters, kg) and imperial (gallons, lbs) units during configuration or via options (Hydrolink backend). The integration automatically displays the correct values based on your preference. The alternative unit is available as an attribute on each sensor (see below). On the iQua backend, the unit system is instead reported by the device itself and mirrored automatically.
 
 
 ## 📦 Features
@@ -22,9 +28,8 @@ This custom integration retrieves real-time data from your Ecowater water soften
 - Binary sensors for regeneration status, salt alerts, leak alerts, system errors, and audible alarm status.
 - Automatic API token renewal.
 - Configurable update interval (via options).
-- Multi-region support (EU and US).
-- Selectable unit system (metric or imperial) with the alternative unit available as an attribute on each sensor.
-- Wake-up mechanism (since v1.2.0) that polls the `/live` endpoint before each update to ensure fresh data, eliminating the need to open the mobile app.
+- **Hydrolink backend:** multi-region support (EU and US), selectable unit system (metric or imperial) with the alternative unit available as an attribute on each sensor, wake-up mechanism (since v1.2.0) that polls the `/live` endpoint before each update to ensure fresh data, eliminating the need to open the mobile app.
+- **iQua backend (since v1.5.0):** support for Aquahome Duo Smart and other iQua-family softeners, a `connectivity` binary sensor, and an optional water shutoff valve switch.
 
 ## 🌐 Language support
 
@@ -66,17 +71,28 @@ The integration is fully configured via the Home Assistant user interface.
 
 1. Go to **Settings → Devices & services**.
 2. Click **Add Integration** and search for "Ecowater Hydrolink Custom".
-3. Enter your login credentials (email and password of your Hydrolink account).
-4. **Select your region** (EU or US). This determines the correct API endpoint.
-5. **Select your preferred unit system** (metric or imperial).
-6. Set the desired **update interval** in minutes (default 5 minutes; 1 minute also works).
-7. Click **Submit**.
+3. **Select which cloud platform / app your device uses:**
+   - **EcoWater Hydrolink** - if you normally check your softener via the *Hydrolink* app.
+   - **EcoWater iQua** - if you use the *iQua* app (this includes the **Aquahome Duo Smart**).
+4. Depending on your choice, fill in the next form:
 
-After successful configuration, all sensors and binary sensors will appear automatically under one device.
+   **Hydrolink:**
+   - Email and password of your Hydrolink account.
+   - **Region** (EU or US) - determines the correct API endpoint.
+   - **Unit system** (metric or imperial).
+   - Update interval in minutes (default 5; 1 minute also works).
+
+   **iQua:**
+   - Email/username and password of your iQua account.
+   - **Device serial number** - open the iQua app, go to your device's settings/info screen to find it.
+   - Update interval in minutes (default 5; 1 minute also works).
+5. Click **Submit**.
+
+After successful configuration, all sensors, binary sensors and (for iQua) the water shutoff valve switch will appear automatically under one device.
 
 ### Changing options
 
-After installation, you can adjust the update interval and unit system via:  
+After installation, you can adjust the update interval (and, for Hydrolink, the unit system) via:  
 **Device → three dots → Options**
 
 > **Note:** When you change the unit system, the displayed values may not update immediately due to Home Assistant's entity state cache. After saving the options, the integration reloads and the new values will appear on the next sensor update. You can also force a refresh by restarting the integration or waiting for the next scheduled poll.
@@ -85,75 +101,115 @@ After installation, you can adjust the update interval and unit system via:
 
 The integration adds the following sensors (all grouped under one device). Units depend on your selected unit system (metric shown below; imperial units will be gallons, gpm, lbs). For each sensor that supports both unit systems, the alternative value is available as an attribute (e.g., `imperial_value` or `metric_value`).
 
-| Sensor | Description | Unit (metric) | Device class | Attributes |
-|--------|-------------|---------------|--------------|------------|
-| `last_update` | Timestamp of last successful update | | timestamp | – |
-| `salt_level_percent` | Current salt level | % | | – |
-| `salt_level_rounded` | Rounded salt level (from API) | % | | – |
-| `out_of_salt_days` | Estimated days until salt runs out | days | | – |
-| `low_salt_trip_days` | Low salt trip level (device setting) | days | | – |
-| `service_reminder` | Service reminder (e.g. "12 months") | | | – |
-| `water_used_today` | Water usage today | L | water | `imperial_value` / `metric_value` |
-| `total_water_used` | Total water usage since installation | L | water | `imperial_value` / `metric_value` |
-| `water_available` | Amount of treated water still available | L | water | `imperial_value` / `metric_value` |
-| `current_flow` | Current flow rate | L/min | water | `imperial_value` / `metric_value` |
-| `avg_daily_use` | Average daily water usage | L | water | `imperial_value` / `metric_value` |
-| `hardness` | Water hardness setting | gpg | | – |
-| `total_regens` | Total number of regenerations | | | – |
-| `manual_regens` | Number of manual regenerations | | | – |
-| `days_since_regen` | Days since last regeneration | days | | – |
-| `avg_days_between_regens` | Average days between regenerations | days | | – |
-| `avg_salt_per_regen` | Average salt consumption per regeneration | kg | | `imperial_value` / `metric_value` |
-| `model` | Water softener model | | | – |
-| `serial` | Serial number | | | – |
-| `software_version` | Controller software version | | | – |
-| `rssi` | Wi-Fi signal strength | dBm | signal_strength | – |
-| `wifi_ssid` | Wi-Fi network name | | | – |
-| `days_in_operation` | Days in operation | days | | – |
-| `power_outages` | Number of power outages | | | – |
-| `dealer_name` | Dealer name | | | – |
-| `dealer_phone` | Dealer phone number | | | – |
-| `rock_removed_since_regen` | Hardness removed since last regeneration | kg | | `imperial_value` / `metric_value` |
-| `total_rock_removed` | Total hardness removed over lifetime | kg | | `imperial_value` / `metric_value` |
-| `total_salt_use` | Total salt consumed over lifetime | kg | | `imperial_value` / `metric_value` |
-| `calculated_daily_use` | Total calculated water use for today | L | water | `imperial_value` / `metric_value` |
-| `water_used_in_last_regen` | Water used during the last regeneration cycle (experimental – needs verification) | L | water | – |
+The **Backend** column shows which cloud platform(s) actually populate each sensor. On iQua, fields marked "Hydrolink only" will show as `unknown` since the iQua API doesn't expose that data (lifetime totals, regeneration counters, dealer info, software/Wi-Fi diagnostics, and alert flags are Hydrolink-specific).
 
-> **Note:** Attributes containing the alternative unit only appear after the sensor has received at least one update with the new unit setting. If you change the unit system, the attributes may be empty until the next data refresh. The `calculated_daily_use` resets to zero after each update. The `water_used_in_last_regen` sensor is experimental and its accuracy depends on whether the device reports total water usage during regeneration (this has not yet been confirmed). It will display `0` until a regeneration cycle has completed after updating.
+| Sensor | Description | Unit (metric) | Device class | Backend | Attributes |
+|--------|-------------|---------------|--------------|---------|------------|
+| `last_update` | Timestamp of last successful update | | timestamp | Both | – |
+| `salt_level_percent` | Current salt level | % | | Both | `raw_tenths` (iQua only, unit unconfirmed) |
+| `salt_level_rounded` | Rounded salt level (from API) | % | | Both | – |
+| `out_of_salt_days` | Estimated days until salt runs out | days | | Both | – |
+| `low_salt_trip_days` | Low salt trip level (device setting) | days | | Hydrolink only | – |
+| `service_reminder` | Service reminder (e.g. "12 months") | | | Hydrolink only | – |
+| `water_used_today` | Water usage today | L | water | Both | `imperial_value` / `metric_value` |
+| `total_water_used` | Total water usage since installation | L | water | Hydrolink only | `imperial_value` / `metric_value` |
+| `water_available` | Amount of treated water still available | L | water | Both | `imperial_value` / `metric_value` |
+| `current_flow` | Current flow rate | L/min | water | Both | `imperial_value` / `metric_value` |
+| `avg_daily_use` | Average daily water usage | L | water | Both | `imperial_value` / `metric_value` |
+| `hardness` | Water hardness setting | gpg | | Both | – |
+| `total_regens` | Total number of regenerations | | | Hydrolink only | – |
+| `manual_regens` | Number of manual regenerations | | | Hydrolink only | – |
+| `days_since_regen` | Days since last regeneration | days | | Both | – |
+| `avg_days_between_regens` | Average days between regenerations | days | | Hydrolink only | – |
+| `avg_salt_per_regen` | Average salt consumption per regeneration | kg | | Hydrolink only | `imperial_value` / `metric_value` |
+| `model` | Water softener model | | | Both | – |
+| `serial` | Serial number | | | Both | – |
+| `software_version` | Controller software version | | | Hydrolink only | – |
+| `rssi` | Wi-Fi signal strength | dBm | signal_strength | Hydrolink only | – |
+| `wifi_ssid` | Wi-Fi network name | | | Hydrolink only | – |
+| `days_in_operation` | Days in operation | days | | Hydrolink only | – |
+| `power_outages` | Number of power outages | | | Hydrolink only | – |
+| `dealer_name` | Dealer name | | | Hydrolink only | – |
+| `dealer_phone` | Dealer phone number | | | Hydrolink only | – |
+| `rock_removed_since_regen` | Hardness removed since last regeneration | kg | | Hydrolink only | `imperial_value` / `metric_value` |
+| `total_rock_removed` | Total hardness removed over lifetime | kg | | Hydrolink only | `imperial_value` / `metric_value` |
+| `total_salt_use` | Total salt consumed over lifetime | kg | | Hydrolink only | `imperial_value` / `metric_value` |
+| `calculated_daily_use` | Total calculated water use for today | L | water | Both | `imperial_value` / `metric_value` |
+| `water_used_in_last_regen` | Water used during the last regeneration cycle (experimental – needs verification) | L | water | Hydrolink only | – |
+
+> **Note:** Attributes containing the alternative unit only appear after the sensor has received at least one update with the new unit setting. If you change the unit system, the attributes may be empty until the next data refresh. On Hydrolink, `calculated_daily_use` is derived from the delta of `total_water_used` between polls and resets to zero after each update; on iQua it simply mirrors `water_used_today`, which the API already tracks per-day. The `water_used_in_last_regen` sensor is experimental and its accuracy depends on whether the device reports total water usage during regeneration (this has not yet been confirmed). It will display `0` until a regeneration cycle has completed after updating.
 
 ## 🚨 Binary sensors
 
-| Binary sensor | Description | Device class |
-|---------------|-------------|--------------|
-| `is_regenerating` | Device is regenerating | running |
-| `salt_alert` | Salt low alert | problem |
-| `leak_alert` | Leak detected | problem |
-| `error_alert` | System error | problem |
-| `alarm_beeping` | Audible alarm is active | sound |
+| Binary sensor | Description | Device class | Backend |
+|---------------|-------------|--------------|---------|
+| `is_regenerating` | Device is regenerating | running | Hydrolink only |
+| `salt_alert` | Salt low alert | problem | Hydrolink only |
+| `leak_alert` | Leak detected | problem | Hydrolink only |
+| `error_alert` | System error | problem | Hydrolink only |
+| `alarm_beeping` | Audible alarm is active | sound | Hydrolink only |
+| `connectivity` | Device is online | connectivity | iQua only |
+
+## 🔌 Switches (iQua only)
+
+| Switch | Description |
+|--------|-------------|
+| `water_shutoff_valve` | Opens/closes the softener's water shutoff valve, if your device has one. |
+
+> **⚠️ Disabled by default.** Turning this switch off closes the main water shutoff valve on your softener - a real, physical action with consequences (no water will flow through the softener until it's opened again). To avoid accidental automations, the entity is created **disabled**. Enable it explicitly via **Settings → Devices & services → Ecowater Hydrolink Custom → Entities**, find `water_shutoff_valve`, and enable it, only if you actually intend to control the valve from Home Assistant.
+>
+> The switch becomes `unavailable` if your specific device doesn't report a valve (some iQua-family models don't have one).
 
 ## ❓ Troubleshooting
 
 ### "No data" or sensors unavailable
-- Verify your login credentials and region selection.
+- Verify your login credentials, and (Hydrolink) region selection, or (iQua) device serial number.
 - Check the Home Assistant logs (**Settings → System → Logs**) for error messages containing `ecowater_hydrolink_custom`.
 
 ### Token expiration
 The integration automatically renews the token when a 401 response is received. If this fails, check your internet connection.
 
 ### Unit change does not update values immediately
-After changing the unit system in the options, the integration reloads. However, due to Home Assistant's entity state cache, the displayed values may still show the old unit for a short time. 
+After changing the unit system in the options, the integration reloads. However, due to Home Assistant's entity state cache, the displayed values may still show the old unit for a short time. This option only applies to the Hydrolink backend; iQua always mirrors the unit reported by the device itself.
 
 ### Attributes not showing
 Attributes containing the alternative unit are only populated after the sensor has received a new value following the unit change. 
 
 ### Unrealistic values for certain sensors
-Some sensors, such as `rock_removed_since_regen`, `total_rock_removed`, and `total_salt_use`, may display values that seem unrealistic (e.g., very high numbers for a newly installed device). These values come directly from the Hydrolink API and are not calculated or modified by the integration. They reflect the data provided by the manufacturer's cloud service.
+Some sensors, such as `rock_removed_since_regen`, `total_rock_removed`, and `total_salt_use`, may display values that seem unrealistic (e.g., very high numbers for a newly installed device). These values come directly from the cloud API and are not calculated or modified by the integration. They reflect the data provided by the manufacturer's cloud service.
+
+### iQua / Aquahome Duo Smart: "No devices found" or wrong data
+- Double-check the device serial number entered during setup - it must match exactly what's shown in the iQua app (device info/settings screen), not an account or dealer ID.
+- The iQua backend is untested against most iQua-family rebrands (Viessmann, North Star, Morton, Whirlpool, Rheem, GE, Kenmore) - it was built from the public iQua API used by Aquahome Duo Smart and community reverse-engineering of the `apioem.ecowater.com` API. If your model reports differently, please open an issue with a redacted example of your device's data.
+- Many fields (lifetime totals, regeneration counters, dealer/Wi-Fi info, alert flags) are simply not available from the iQua dashboard endpoint and will always show as `unknown` - see the Backend column in the sensors table above.
 
 ### Known limitations
 - Not tested on multiple devices under a single account.
-- The `water_used_in_last_regen` sensor is experimental; its accuracy is not guaranteed and depends on the device's update behavior during regeneration.
+- The `water_used_in_last_regen` sensor is experimental; its accuracy is not guaranteed and depends on the device's update behavior during regeneration. It is Hydrolink-only.
+- The iQua backend (Aquahome Duo Smart and related rebrands) has only been validated against the public API contract, not a wide range of real devices - please report any discrepancies.
+- The unit of the `raw_tenths` attribute on `salt_level_percent` (iQua only) has not been confirmed against a real device; treat it as informational only.
 
 ## 📝 Changelog
+
+### v1.5.0 – Added EcoWater iQua backend support (Aquahome Duo Smart and other iQua-family softeners) - 2026-08-17
+
+This release adds support for water softeners managed through the **iQua** app (`apioem.ecowater.com`) instead of Hydrolink - most notably the **Aquahome Duo Smart**, and (untested) other iQua-family rebrands such as Viessmann, North Star, Morton, Whirlpool, Rheem, GE and Kenmore softeners.
+
+#### ✨ New features
+- **New "cloud platform" selection step** at the start of setup - choose Hydrolink or iQua.
+- **iQua backend**: login with your iQua account and device serial number; reuses the existing sensor/binary_sensor entities where the data is equivalent.
+- **`connectivity` binary sensor** (iQua only) - reflects the device's online/offline state.
+- **`water_shutoff_valve` switch** (iQua only, **disabled by default**) - opens/closes the softener's main water shutoff valve, for devices that report one.
+- **`raw_tenths` attribute** on `salt_level_percent` (iQua only) - the raw, not-yet-unit-confirmed salt reading from the API.
+
+#### 🔧 Improvements
+- Refactored the shared HTTP retry logic into a small internal helper module reused by both backends.
+- Fixed an inconsistency where the device name shown in Home Assistant differed slightly between sensors and binary sensors.
+
+#### 📝 Notes
+- Existing Hydrolink configurations are unaffected and continue to work without any changes; a silent migration adds the new "backend" field in the background.
+- The iQua backend exposes noticeably fewer fields than Hydrolink (see the Backend column in the sensor tables) since the underlying API is simpler.
+- The water shutoff valve switch is deliberately disabled by default given the real-world consequence of closing it - see [🔌 Switches](#-switches-iqua-only).
 
 ### v1.4.0 – Added water usage during last regeneration sensor (experimental) - 2026-06-19
 

--- a/custom_components/ecowater_hydrolink_custom/__init__.py
+++ b/custom_components/ecowater_hydrolink_custom/__init__.py
@@ -4,14 +4,19 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN, PLATFORMS
+from .const import DOMAIN, PLATFORMS, CONF_BACKEND, BACKEND_HYDROLINK, BACKEND_IQUA
 from .coordinator import EcowaterCoordinator
+from .iqua_coordinator import IquaCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Ecowater Hydrolink Custom from a config entry."""
-    coordinator = EcowaterCoordinator(hass, entry)
+    backend = entry.data.get(CONF_BACKEND, BACKEND_HYDROLINK)
+    if backend == BACKEND_IQUA:
+        coordinator = IquaCoordinator(hass, entry)
+    else:
+        coordinator = EcowaterCoordinator(hass, entry)
 
     try:
         await coordinator.async_config_entry_first_refresh()

--- a/custom_components/ecowater_hydrolink_custom/binary_sensor.py
+++ b/custom_components/ecowater_hydrolink_custom/binary_sensor.py
@@ -1,12 +1,12 @@
 import logging
 from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from .const import DOMAIN
+from .const import DOMAIN, BACKEND_IQUA
 
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    """Stel binary_sensorplatform in."""
+    """Set up the binary_sensor platform from a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
     _LOGGER.debug("Setting up Ecowater binary sensors")
 
@@ -18,13 +18,20 @@ async def async_setup_entry(hass, entry, async_add_entities):
         EcoWaterBinarySensor(coordinator, "alarm_beeping", BinarySensorDeviceClass.SOUND),
     ]
 
-    _LOGGER.debug("Aantal binary sensors om toe te voegen: %d", len(binary_sensors))
+    # The iQua backend reports an explicit online/offline device state that
+    # Hydrolink does not expose.
+    if getattr(coordinator, "backend", None) == BACKEND_IQUA:
+        binary_sensors.append(
+            EcoWaterBinarySensor(coordinator, "connectivity", BinarySensorDeviceClass.CONNECTIVITY)
+        )
+
+    _LOGGER.debug("Number of binary sensors to add: %d", len(binary_sensors))
     async_add_entities(binary_sensors)
-    _LOGGER.debug("Binary sensors toegevoegd aan Home Assistant")
+    _LOGGER.debug("Binary sensors added to Home Assistant")
 
 
 class EcoWaterBinarySensor(CoordinatorEntity, BinarySensorEntity):
-    """Vertegenwoordigt een Ecowater binary sensor."""
+    """Representation of an Ecowater binary sensor."""
 
     # Icon mapping per binary sensor key
     _icon_map = {
@@ -33,6 +40,7 @@ class EcoWaterBinarySensor(CoordinatorEntity, BinarySensorEntity):
         "leak_alert": "mdi:pipe-leak",
         "error_alert": "mdi:alert-circle",
         "alarm_beeping": "mdi:bell-ring",
+        "connectivity": "mdi:wifi",
     }
 
     def __init__(self, coordinator, data_key, device_class):
@@ -44,19 +52,19 @@ class EcoWaterBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._attr_unique_id = f"{DOMAIN}_bin_{data_key}_{coordinator.entry.entry_id}"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, coordinator.entry.entry_id)},
-            "name": "Ecowater Waterontharder",
+            "name": "Ecowater Water Softener",
             "manufacturer": "EcoWater",
             "model": coordinator.data.get("model") if coordinator.data else None,
         }
 
     @property
     def icon(self):
-        """Bepaal het icoon op basis van de sensor key."""
+        """Return the icon to use in the frontend, based on the sensor key."""
         return self._icon_map.get(self._data_key, "mdi:help")
 
     @property
     def is_on(self):
-        """Geef True als de binary sensor 'aan' is."""
+        """Return True if the binary sensor is 'on'."""
         if self.coordinator.data:
             value = self.coordinator.data.get(self._data_key, False)
             _LOGGER.debug("Binary sensor %s: key=%s, value=%s", self.entity_id, self._data_key, value)
@@ -66,5 +74,5 @@ class EcoWaterBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def available(self):
-        """Geef beschikbaarheid op basis van de coordinator."""
+        """Return availability based on the coordinator."""
         return self.coordinator.last_update_success

--- a/custom_components/ecowater_hydrolink_custom/config_flow.py
+++ b/custom_components/ecowater_hydrolink_custom/config_flow.py
@@ -8,12 +8,17 @@ from .const import (
     DOMAIN,
     CONF_USERNAME,
     CONF_PASSWORD,
+    CONF_BACKEND,
+    BACKEND_HYDROLINK,
+    BACKEND_IQUA,
+    BACKEND_OPTIONS,
     CONF_REGION,
     REGION_EU,
     REGION_US,
     CONF_UNIT_SYSTEM,
     UNIT_METRIC,
     UNIT_OPTIONS,
+    CONF_DEVICE_SERIAL,
     SCAN_INTERVAL_MINUTES,
     DEFAULT_SCAN_INTERVAL,
 )
@@ -23,16 +28,31 @@ _LOGGER = logging.getLogger(__name__)
 class EcowaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Ecowater Hydrolink Custom."""
 
-    VERSION = 2
+    VERSION = 3
 
     async def async_step_user(self, user_input=None):
-        """Step called when the user adds the integration."""
+        """First step: choose which EcoWater cloud backend/app the device uses."""
+        if user_input is not None:
+            if user_input[CONF_BACKEND] == BACKEND_IQUA:
+                return await self.async_step_iqua()
+            return await self.async_step_hydrolink()
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_BACKEND, default=BACKEND_HYDROLINK): vol.In(BACKEND_OPTIONS),
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=data_schema)
+
+    async def async_step_hydrolink(self, user_input=None):
+        """Step for the Hydrolink backend (Hydrolink app)."""
         errors = {}
 
         if user_input is not None:
+            data = {**user_input, CONF_BACKEND: BACKEND_HYDROLINK}
             return self.async_create_entry(
                 title="Ecowater Hydrolink Custom",
-                data=user_input
+                data=data
             )
 
         data_schema = vol.Schema(
@@ -53,7 +73,35 @@ class EcowaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
         return self.async_show_form(
-            step_id="user",
+            step_id="hydrolink",
+            data_schema=data_schema,
+            errors=errors,
+        )
+
+    async def async_step_iqua(self, user_input=None):
+        """Step for the iQua backend (iQua app, e.g. Aquahome Duo Smart)."""
+        errors = {}
+
+        if user_input is not None:
+            data = {**user_input, CONF_BACKEND: BACKEND_IQUA}
+            return self.async_create_entry(
+                title=f"Ecowater iQua {user_input[CONF_DEVICE_SERIAL]}",
+                data=data
+            )
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_USERNAME): str,
+                vol.Required(CONF_PASSWORD): str,
+                vol.Required(CONF_DEVICE_SERIAL): str,
+                vol.Optional(
+                    SCAN_INTERVAL_MINUTES, default=DEFAULT_SCAN_INTERVAL
+                ): int,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="iqua",
             data_schema=data_schema,
             errors=errors,
         )
@@ -64,13 +112,21 @@ class EcowaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return EcowaterOptionsFlowHandler(config_entry)
 
     async def async_migrate_entry(self, hass, config_entry):
-        """Migrate old entry."""
+        """Migrate old entries."""
         _LOGGER.debug("Migrating from version %s", config_entry.version)
+
         if config_entry.version == 1:
             new_data = {**config_entry.data, CONF_REGION: REGION_EU}
             config_entry.version = 2
             hass.config_entries.async_update_entry(config_entry, data=new_data)
             _LOGGER.debug("Migration to version 2 complete")
+
+        if config_entry.version == 2:
+            new_data = {**config_entry.data, CONF_BACKEND: BACKEND_HYDROLINK}
+            config_entry.version = 3
+            hass.config_entries.async_update_entry(config_entry, data=new_data)
+            _LOGGER.debug("Migration to version 3 complete")
+
         return True
 
 
@@ -86,24 +142,27 @@ class EcowaterOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 
-        # Determine current values
-        current_unit = self.config_entry.options.get(
-            CONF_UNIT_SYSTEM,
-            self.config_entry.data.get(CONF_UNIT_SYSTEM, UNIT_METRIC)
-        )
+        backend = self.config_entry.data.get(CONF_BACKEND, BACKEND_HYDROLINK)
+
         current_interval = self.config_entry.options.get(
             SCAN_INTERVAL_MINUTES,
             self.config_entry.data.get(SCAN_INTERVAL_MINUTES, DEFAULT_SCAN_INTERVAL)
         )
 
-        data_schema = vol.Schema(
-            {
-                vol.Required(CONF_UNIT_SYSTEM, default=current_unit): vol.In(UNIT_OPTIONS),
-                vol.Optional(SCAN_INTERVAL_MINUTES, default=current_interval): int,
-            }
-        )
+        schema_dict = {}
+
+        # Unit system is only user-selectable on Hydrolink; iQua reports its
+        # own unit per device.
+        if backend == BACKEND_HYDROLINK:
+            current_unit = self.config_entry.options.get(
+                CONF_UNIT_SYSTEM,
+                self.config_entry.data.get(CONF_UNIT_SYSTEM, UNIT_METRIC)
+            )
+            schema_dict[vol.Required(CONF_UNIT_SYSTEM, default=current_unit)] = vol.In(UNIT_OPTIONS)
+
+        schema_dict[vol.Optional(SCAN_INTERVAL_MINUTES, default=current_interval)] = int
 
         return self.async_show_form(
             step_id="init",
-            data_schema=data_schema,
+            data_schema=vol.Schema(schema_dict),
         )

--- a/custom_components/ecowater_hydrolink_custom/const.py
+++ b/custom_components/ecowater_hydrolink_custom/const.py
@@ -6,12 +6,24 @@ NAME = "Ecowater Hydrolink Custom"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 
-# Region selection
+# Backend / cloud platform selection.
+# HYDROLINK: app.hydrolinkhome.eu / .com - EcoWater "Hydrolink" app.
+# IQUA: apioem.ecowater.com - EcoWater "iQua" app family, used by e.g.
+#       Aquahome Duo Smart, Viessmann, North Star, Morton, Rheem, GE, Kenmore.
+CONF_BACKEND = "backend"
+BACKEND_HYDROLINK = "hydrolink"
+BACKEND_IQUA = "iqua"
+BACKEND_OPTIONS = {
+    BACKEND_HYDROLINK: "EcoWater Hydrolink (Hydrolink app)",
+    BACKEND_IQUA: "EcoWater iQua (iQua app, e.g. Aquahome Duo Smart)",
+}
+
+# Region selection (Hydrolink backend only)
 CONF_REGION = "region"
 REGION_EU = "EU"
 REGION_US = "US"
 
-# Unit system selection
+# Unit system selection (Hydrolink backend only - iQua reports its own unit)
 CONF_UNIT_SYSTEM = "unit_system"
 UNIT_METRIC = "metric"
 UNIT_IMPERIAL = "imperial"
@@ -20,7 +32,7 @@ UNIT_OPTIONS = {
     UNIT_IMPERIAL: "Imperial (gallons, lbs)",
 }
 
-# Base URLs per region
+# Base URLs per region (Hydrolink backend)
 BASE_URLS = {
     REGION_EU: "https://api.hydrolinkhome.eu/v1",
     REGION_US: "https://api.hydrolinkhome.com/v1",
@@ -39,4 +51,15 @@ HEADERS = {
     "X-Requested-With": "XMLHttpRequest",
 }
 
-PLATFORMS = ["sensor", "binary_sensor"]
+# iQua backend (Aquahome Duo Smart and other iQua-family softeners)
+CONF_DEVICE_SERIAL = "device_serial_number"
+IQUA_BASE_URL = "https://apioem.ecowater.com/v1"
+# Mimics the official iQua Android app; the API has been observed to be
+# strict about the User-Agent header.
+IQUA_USER_AGENT = "okhttp/4.9.1"
+# waterShutoffValveReq values reported by the iQua dashboard endpoint.
+IQUA_VALVE_CLOSED = 0
+IQUA_VALVE_OPEN = 1
+IQUA_VALVE_NOT_PRESENT = 2
+
+PLATFORMS = ["sensor", "binary_sensor", "switch"]

--- a/custom_components/ecowater_hydrolink_custom/coordinator.py
+++ b/custom_components/ecowater_hydrolink_custom/coordinator.py
@@ -5,12 +5,7 @@ It acts as the central data hub for the integration.
 """
 
 import logging
-import asyncio
 from datetime import timedelta
-
-import aiohttp
-import async_timeout
-from aiohttp.client_exceptions import ClientConnectorDNSError, ClientError
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -28,7 +23,9 @@ from .const import (
     HEADERS,
     SCAN_INTERVAL_MINUTES,
     DEFAULT_SCAN_INTERVAL,
+    BACKEND_HYDROLINK,
 )
+from .net import async_request_with_retry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,6 +51,7 @@ class EcowaterCoordinator(DataUpdateCoordinator):
             entry: ConfigEntry containing user configuration
         """
         self.entry = entry
+        self.backend = BACKEND_HYDROLINK
 
         # Region selection (default to EU if not set)
         self.region = entry.data.get(CONF_REGION, REGION_EU)
@@ -126,25 +124,7 @@ class EcowaterCoordinator(DataUpdateCoordinator):
         Raises:
             Exception if all retries fail
         """
-        max_retries = 2
-        for attempt in range(max_retries + 1):
-            try:
-                async with async_timeout.timeout(20):
-                    return await self.session.request(method, url, **kwargs)
-            except (ClientConnectorDNSError, ClientError, asyncio.TimeoutError) as err:
-                if attempt < max_retries:
-                    wait = 2 * (attempt + 1)
-                    _LOGGER.warning(
-                        "Error on %s %s (attempt %d/%d): %s. Retrying in %s seconds.",
-                        method, url, attempt + 1, max_retries + 1, err, wait
-                    )
-                    await asyncio.sleep(wait)
-                else:
-                    _LOGGER.error("Max retries reached for %s %s", method, url)
-                    raise
-            except Exception as err:
-                _LOGGER.exception("Unexpected error on %s %s", method, url)
-                raise
+        return await async_request_with_retry(self.session, method, url, **kwargs)
 
     async def _get_token(self):
         """Obtain a new access token from the login endpoint.
@@ -168,7 +148,7 @@ class EcowaterCoordinator(DataUpdateCoordinator):
             else:
                 _LOGGER.error("No token in response: %s", data)
             return token
-        except Exception as ex:
+        except Exception:
             _LOGGER.exception("Authentication failed for Ecowater")
             return None
 

--- a/custom_components/ecowater_hydrolink_custom/iqua_coordinator.py
+++ b/custom_components/ecowater_hydrolink_custom/iqua_coordinator.py
@@ -1,0 +1,268 @@
+"""Coordinator for the EcoWater iQua backend.
+
+This backend is used by the iQua app family (apioem.ecowater.com), which
+covers devices such as the Aquahome Duo Smart as well as several other
+rebranded EcoWater-platform softeners (Viessmann, North Star, Morton,
+Whirlpool, Rheem, GE, Kenmore, ...).
+
+Unlike the Hydrolink backend, iQua:
+- Requires the device serial number to be entered by the user (there is no
+  "list my devices" endpoint in general use).
+- Reports its own volume unit per device instead of letting the user pick
+  metric/imperial.
+- Exposes a controllable water shutoff valve.
+- Exposes far fewer historical/lifetime fields than Hydrolink (no lifetime
+  totals, regeneration counters, dealer info, etc.).
+
+The output of `_async_update_data` uses the same canonical dict keys as the
+Hydrolink coordinator wherever the underlying data is equivalent, so the
+`sensor` and `binary_sensor` platforms can stay backend-agnostic. Keys that
+have no iQua equivalent are set to a neutral default (None/False).
+"""
+
+import logging
+from datetime import timedelta
+
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    DOMAIN,
+    CONF_USERNAME,
+    CONF_PASSWORD,
+    CONF_DEVICE_SERIAL,
+    IQUA_BASE_URL,
+    IQUA_USER_AGENT,
+    IQUA_VALVE_CLOSED,
+    IQUA_VALVE_OPEN,
+    SCAN_INTERVAL_MINUTES,
+    DEFAULT_SCAN_INTERVAL,
+    UNIT_METRIC,
+    UNIT_IMPERIAL,
+    BACKEND_IQUA,
+)
+from .net import async_request_with_retry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class IquaCoordinator(DataUpdateCoordinator):
+    """Coordinator for the iQua/OEM cloud API."""
+
+    # Exposed for the switch/binary_sensor platforms to know this backend
+    # supports valve control and a connectivity state.
+    supports_valve_control = True
+
+    def __init__(self, hass, entry):
+        """Initialize the coordinator.
+
+        Args:
+            hass: HomeAssistant instance
+            entry: ConfigEntry containing user configuration
+        """
+        self.entry = entry
+        self.backend = BACKEND_IQUA
+        self.device_serial = entry.data[CONF_DEVICE_SERIAL]
+        self.language = hass.config.language[:2]
+
+        # iQua reports its own unit per device; default until first update.
+        self.unit_system = UNIT_METRIC
+
+        interval = entry.options.get(
+            SCAN_INTERVAL_MINUTES,
+            entry.data.get(SCAN_INTERVAL_MINUTES, DEFAULT_SCAN_INTERVAL)
+        )
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(minutes=interval)
+        )
+
+        self.session = async_get_clientsession(hass)
+        self._token = None
+        self._token_type = None
+        self._token_expires = None
+        _LOGGER.debug("IquaCoordinator initialized for serial %s", self.device_serial)
+
+    def _headers(self, with_auth=True):
+        """Build request headers, optionally including the bearer token."""
+        headers = {"User-Agent": IQUA_USER_AGENT}
+        if with_auth and self._token and self._token_type:
+            headers["Authorization"] = f"{self._token_type} {self._token}"
+        return headers
+
+    async def _ensure_token(self):
+        """Log in if we have no token yet, or it has expired."""
+        if self._token is None or (
+            self._token_expires is not None and dt_util.utcnow() > self._token_expires
+        ):
+            await self._login()
+
+    async def _login(self):
+        """Authenticate against the iQua API and store the bearer token."""
+        payload = {
+            "username": self.entry.data[CONF_USERNAME],
+            "password": self.entry.data[CONF_PASSWORD],
+        }
+        try:
+            response = await async_request_with_retry(
+                self.session, "POST", f"{IQUA_BASE_URL}/auth/signin",
+                json=payload, headers=self._headers(with_auth=False),
+            )
+        except Exception as ex:
+            raise UpdateFailed(f"Could not reach EcoWater iQua login endpoint: {ex}") from ex
+
+        if response.status == 401:
+            raise UpdateFailed("Authentication failed for EcoWater iQua (check username/password)")
+        response.raise_for_status()
+        body = await response.json()
+        if body.get("code") != "OK":
+            raise UpdateFailed(f"iQua login error: {body.get('code')} ({body.get('message')})")
+
+        data = body["data"]
+        self._token = data["token"]
+        self._token_type = data["tokenType"]
+        self._token_expires = dt_util.utcnow() + timedelta(seconds=int(data["expiresIn"]))
+        _LOGGER.debug("iQua token obtained, expires %s", self._token_expires)
+
+    async def _request_json(self, method, path, **kwargs):
+        """Perform an authenticated request, retrying once after a re-login on 401."""
+        await self._ensure_token()
+        url = f"{IQUA_BASE_URL}/{path}"
+        response = await async_request_with_retry(
+            self.session, method, url, headers=self._headers(), **kwargs
+        )
+        if response.status == 401:
+            await self._login()
+            response = await async_request_with_retry(
+                self.session, method, url, headers=self._headers(), **kwargs
+            )
+        response.raise_for_status()
+        body = await response.json()
+        if body.get("code") != "OK":
+            raise UpdateFailed(f"iQua request error: {body.get('code')} ({body.get('message')})")
+        return body["data"]
+
+    def _parse_device_data(self, data):
+        """Map the raw iQua dashboard payload onto the integration's canonical data dict.
+
+        Args:
+            data: The "data" object from the /system/{serial}/dashboard response.
+
+        Returns:
+            dict: Mapped sensor data ready for use by sensor/binary_sensor/switch entities.
+        """
+
+        def raw(key, default=None):
+            return data.get(key, {}).get("value", default)
+
+        def as_int(key, default=None):
+            value = raw(key)
+            return int(value) if value is not None else default
+
+        def as_float(key, default=None):
+            value = raw(key)
+            return float(value) if value is not None else default
+
+        # 0 = gallons, 1 = liters
+        volume_unit = as_int("volumeUnitEnum", 0)
+        self.unit_system = UNIT_METRIC if volume_unit == 1 else UNIT_IMPERIAL
+
+        salt_percent = data.get("saltLevelTenths", {}).get("percent")
+        salt_tenths = raw("saltLevelTenths")
+
+        return {
+            "last_update": dt_util.now(),
+            "model": f'{raw("modelDescription")} ({raw("modelId")})',
+            "serial": self.device_serial,
+            "connectivity": data.get("power") == "Online",
+
+            "salt_level_percent": salt_percent,
+            "salt_level_rounded": salt_percent,
+            # Raw value is in tenths of a unit whose exact unit (lb/kg) has
+            # not been confirmed against a real device - exposed as-is only.
+            "salt_level_raw_tenths": salt_tenths,
+            "out_of_salt_days": as_int("outOfSaltEstDays"),
+
+            "water_used_today": as_int("gallonsUsedToday"),
+            "calculated_daily_use": as_int("gallonsUsedToday"),
+            "avg_daily_use": as_int("avgDailyUseGallons"),
+            "water_available": as_int("totalWaterAvailGals"),
+            "current_flow": as_float("currentWaterFlow"),
+            "days_since_regen": as_int("daysSinceLastRegen"),
+            "hardness": as_int("hardnessGrains"),
+
+            "water_shutoff_valve_state": as_int("waterShutoffValveReq"),
+
+            # Not exposed by the iQua dashboard endpoint.
+            "low_salt_trip_days": None,
+            "service_reminder": None,
+            "total_water_used": None,
+            "total_regens": None,
+            "manual_regens": None,
+            "avg_days_between_regens": None,
+            "avg_salt_per_regen": None,
+            "software_version": None,
+            "rssi": None,
+            "wifi_ssid": None,
+            "days_in_operation": None,
+            "power_outages": None,
+            "dealer_name": None,
+            "dealer_phone": None,
+            "rock_removed_since_regen": None,
+            "total_rock_removed": None,
+            "total_salt_use": None,
+            "water_used_in_last_regen": None,
+            "is_regenerating": False,
+            "salt_alert": False,
+            "leak_alert": False,
+            "error_alert": False,
+            "alarm_beeping": False,
+        }
+
+    async def _async_update_data(self):
+        """Periodically called by the base class to refresh data."""
+        _LOGGER.debug("_async_update_data (iQua) STARTED at %s", dt_util.now())
+        try:
+            data = await self._request_json("GET", f"system/{self.device_serial}/dashboard")
+            parsed = self._parse_device_data(data)
+            _LOGGER.debug("_async_update_data (iQua) successful, data keys: %s", list(parsed.keys()))
+            return parsed
+        except UpdateFailed:
+            raise
+        except Exception as err:
+            _LOGGER.exception("Error fetching EcoWater iQua data")
+            raise UpdateFailed(f"Update failed: {err}")
+
+    async def async_set_water_shutoff_valve(self, state: int):
+        """Open or close the water shutoff valve.
+
+        Args:
+            state: IQUA_VALVE_OPEN (1) or IQUA_VALVE_CLOSED (0).
+        """
+        if state not in (IQUA_VALVE_CLOSED, IQUA_VALVE_OPEN):
+            raise ValueError("Invalid water shutoff valve state (must be 0 or 1)")
+
+        await self._ensure_token()
+        url = f"{IQUA_BASE_URL}/system/{self.device_serial}/properties"
+        payload = {"waterShutoffValve": state}
+
+        response = await async_request_with_retry(
+            self.session, "PUT", url, json=payload, headers=self._headers()
+        )
+        if response.status == 401:
+            await self._login()
+            response = await async_request_with_retry(
+                self.session, "PUT", url, json=payload, headers=self._headers()
+            )
+        response.raise_for_status()
+        body = await response.json()
+        if body.get("code") != "OK":
+            raise UpdateFailed(
+                f"Failed to set water shutoff valve: {body.get('code')} ({body.get('message')})"
+            )
+
+        await self.async_request_refresh()

--- a/custom_components/ecowater_hydrolink_custom/iqua_coordinator.py
+++ b/custom_components/ecowater_hydrolink_custom/iqua_coordinator.py
@@ -115,11 +115,19 @@ class IquaCoordinator(DataUpdateCoordinator):
         except Exception as ex:
             raise UpdateFailed(f"Could not reach EcoWater iQua login endpoint: {ex}") from ex
 
-        if response.status == 401:
-            raise UpdateFailed("Authentication failed for EcoWater iQua (check username/password)")
-        response.raise_for_status()
+        if response.status != 200:
+            body_text = await response.text()
+            _LOGGER.error(
+                "EcoWater iQua login failed with status %s: %s",
+                response.status, body_text
+            )
+            if response.status == 401:
+                raise UpdateFailed("Authentication failed for EcoWater iQua (check username/password)")
+            raise UpdateFailed(f"iQua login failed with status {response.status}")
+
         body = await response.json()
         if body.get("code") != "OK":
+            _LOGGER.error("iQua login response: %s", body)
             raise UpdateFailed(f"iQua login error: {body.get('code')} ({body.get('message')})")
 
         data = body["data"]

--- a/custom_components/ecowater_hydrolink_custom/manifest.json
+++ b/custom_components/ecowater_hydrolink_custom/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ecowater_hydrolink_custom",
   "name": "Ecowater Hydrolink Custom",
-  "version": "1.5.0",
+  "version": "1.5.0-beta.1",
   "documentation": "https://github.com/roeli1996/ha-ecowater-hydrolink",
   "issue_tracker": "https://github.com/roeli1996/ha-ecowater-hydrolink/issues",
   "dependencies": [],

--- a/custom_components/ecowater_hydrolink_custom/manifest.json
+++ b/custom_components/ecowater_hydrolink_custom/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ecowater_hydrolink_custom",
   "name": "Ecowater Hydrolink Custom",
-  "version": "1.5.0-beta.1",
+  "version": "1.5.0-beta.2",
   "documentation": "https://github.com/roeli1996/ha-ecowater-hydrolink",
   "issue_tracker": "https://github.com/roeli1996/ha-ecowater-hydrolink/issues",
   "dependencies": [],

--- a/custom_components/ecowater_hydrolink_custom/manifest.json
+++ b/custom_components/ecowater_hydrolink_custom/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ecowater_hydrolink_custom",
   "name": "Ecowater Hydrolink Custom",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "documentation": "https://github.com/roeli1996/ha-ecowater-hydrolink",
   "issue_tracker": "https://github.com/roeli1996/ha-ecowater-hydrolink/issues",
   "dependencies": [],

--- a/custom_components/ecowater_hydrolink_custom/net.py
+++ b/custom_components/ecowater_hydrolink_custom/net.py
@@ -1,0 +1,46 @@
+"""Shared HTTP request helper used by both the Hydrolink and iQua coordinators."""
+
+import asyncio
+import logging
+
+import async_timeout
+from aiohttp.client_exceptions import ClientConnectorDNSError, ClientError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_request_with_retry(session, method, url, *, max_retries=2, timeout=20, **kwargs):
+    """Perform an HTTP request with automatic retries on DNS/network errors.
+
+    Args:
+        session: aiohttp.ClientSession to use.
+        method: HTTP method (GET, POST, PUT, ...).
+        url: Full URL.
+        max_retries: Number of retries after the initial attempt.
+        timeout: Per-attempt timeout in seconds.
+        **kwargs: Additional arguments forwarded to session.request.
+
+    Returns:
+        aiohttp.ClientResponse on success.
+
+    Raises:
+        Exception if all retries fail.
+    """
+    for attempt in range(max_retries + 1):
+        try:
+            async with async_timeout.timeout(timeout):
+                return await session.request(method, url, **kwargs)
+        except (ClientConnectorDNSError, ClientError, asyncio.TimeoutError) as err:
+            if attempt < max_retries:
+                wait = 2 * (attempt + 1)
+                _LOGGER.warning(
+                    "Error on %s %s (attempt %d/%d): %s. Retrying in %s seconds.",
+                    method, url, attempt + 1, max_retries + 1, err, wait
+                )
+                await asyncio.sleep(wait)
+            else:
+                _LOGGER.error("Max retries reached for %s %s", method, url)
+                raise
+        except Exception:
+            _LOGGER.exception("Unexpected error on %s %s", method, url)
+            raise

--- a/custom_components/ecowater_hydrolink_custom/sensor.py
+++ b/custom_components/ecowater_hydrolink_custom/sensor.py
@@ -394,5 +394,11 @@ class EcoWaterSensor(CoordinatorEntity, SensorEntity):
                 "total_salt_use_imperial",
                 "kg", "lbs"
             )
+        elif self._key == "salt_level_percent":
+            # Only populated on the iQua backend; the unit of this raw value
+            # has not been confirmed against a real device.
+            raw_tenths = self.coordinator.data.get("salt_level_raw_tenths")
+            if raw_tenths is not None:
+                attrs["raw_tenths"] = raw_tenths
 
         return attrs

--- a/custom_components/ecowater_hydrolink_custom/strings.json
+++ b/custom_components/ecowater_hydrolink_custom/strings.json
@@ -3,6 +3,13 @@
     "step": {
       "user": {
         "title": "Ecowater Hydrolink Custom",
+        "description": "Select which EcoWater app your water softener uses.",
+        "data": {
+          "backend": "Cloud platform / app"
+        }
+      },
+      "hydrolink": {
+        "title": "Hydrolink login",
         "description": "Enter your Hydrolink login credentials to connect to your water softener.",
         "data": {
           "username": "Username (Email)",
@@ -11,10 +18,20 @@
           "unit_system": "Unit system",
           "scan_interval_minutes": "Update interval (minutes)"
         }
+      },
+      "iqua": {
+        "title": "iQua login",
+        "description": "Enter your iQua login credentials and device serial number (e.g. for Aquahome Duo Smart). The serial number can be found in the iQua app under your device's settings/info screen.",
+        "data": {
+          "username": "Username (Email)",
+          "password": "Password",
+          "device_serial_number": "Device serial number",
+          "scan_interval_minutes": "Update interval (minutes)"
+        }
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to the Hydrolink API.",
+      "cannot_connect": "Failed to connect to the API.",
       "invalid_auth": "Invalid username or password.",
       "unknown": "An unexpected error occurred."
     },
@@ -73,7 +90,11 @@
       "salt_alert": { "name": "Salt alert" },
       "leak_alert": { "name": "Leak alert" },
       "error_alert": { "name": "System error alert" },
-      "alarm_beeping": { "name": "Alarm beeping" }
+      "alarm_beeping": { "name": "Alarm beeping" },
+      "connectivity": { "name": "Connectivity" }
+    },
+    "switch": {
+      "water_shutoff_valve": { "name": "Water shutoff valve" }
     }
   }
 }

--- a/custom_components/ecowater_hydrolink_custom/switch.py
+++ b/custom_components/ecowater_hydrolink_custom/switch.py
@@ -1,0 +1,71 @@
+"""Switch platform for Ecowater Hydrolink Custom integration.
+
+Only the iQua backend exposes a controllable water shutoff valve; on the
+Hydrolink backend this platform adds no entities.
+"""
+
+import logging
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, BACKEND_IQUA, IQUA_VALVE_OPEN, IQUA_VALVE_CLOSED
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the switch platform from a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    if getattr(coordinator, "backend", None) != BACKEND_IQUA:
+        return
+
+    async_add_entities([EcoWaterShutoffValveSwitch(coordinator)])
+
+
+class EcoWaterShutoffValveSwitch(CoordinatorEntity, SwitchEntity):
+    """Representation of the water shutoff valve as a switch.
+
+    Disabled by default: closing the main water shutoff valve is a
+    consequential physical action, so it requires an explicit opt-in from
+    the user in the entity registry before it becomes active.
+    """
+
+    _attr_translation_key = "water_shutoff_valve"
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:water-pump"
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{DOMAIN}_water_shutoff_valve_{coordinator.entry.entry_id}"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, coordinator.entry.entry_id)},
+            "name": "Ecowater Water Softener",
+            "manufacturer": "EcoWater",
+            "model": coordinator.data.get("model") if coordinator.data else None,
+        }
+
+    @property
+    def is_on(self):
+        """Return True if the valve is open."""
+        if self.coordinator.data:
+            return self.coordinator.data.get("water_shutoff_valve_state") == IQUA_VALVE_OPEN
+        return False
+
+    @property
+    def available(self):
+        """Return False if the device has no shutoff valve, or is unreachable."""
+        if not self.coordinator.last_update_success or not self.coordinator.data:
+            return False
+        state = self.coordinator.data.get("water_shutoff_valve_state")
+        return state in (IQUA_VALVE_OPEN, IQUA_VALVE_CLOSED)
+
+    async def async_turn_on(self, **kwargs):
+        """Open the water shutoff valve."""
+        await self.coordinator.async_set_water_shutoff_valve(IQUA_VALVE_OPEN)
+
+    async def async_turn_off(self, **kwargs):
+        """Close the water shutoff valve."""
+        await self.coordinator.async_set_water_shutoff_valve(IQUA_VALVE_CLOSED)

--- a/custom_components/ecowater_hydrolink_custom/translations/de.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/de.json
@@ -3,6 +3,13 @@
     "step": {
       "user": {
         "title": "Ecowater Hydrolink Custom",
+        "description": "Wählen Sie, welche EcoWater-App Ihr Wasserenthärter verwendet.",
+        "data": {
+          "backend": "Cloud-Plattform / App"
+        }
+      },
+      "hydrolink": {
+        "title": "Hydrolink-Anmeldung",
         "description": "Geben Sie Ihre Hydrolink Plus Anmeldedaten ein, um eine Verbindung zu Ihrem Wasserenthärter herzustellen.",
         "data": {
           "username": "Benutzername (E-Mail)",
@@ -11,10 +18,20 @@
           "unit_system": "Einheitensystem",
           "scan_interval_minutes": "Aktualisierungsintervall (Minuten)"
         }
+      },
+      "iqua": {
+        "title": "iQua-Anmeldung",
+        "description": "Geben Sie Ihre iQua-Anmeldedaten und die Seriennummer Ihres Geräts ein (z. B. für Aquahome Duo Smart). Die Seriennummer finden Sie in der iQua-App unter den Geräteinformationen/-einstellungen.",
+        "data": {
+          "username": "Benutzername (E-Mail)",
+          "password": "Passwort",
+          "device_serial_number": "Seriennummer des Geräts",
+          "scan_interval_minutes": "Aktualisierungsintervall (Minuten)"
+        }
       }
     },
     "error": {
-      "cannot_connect": "Verbindung zur Hydrolink-API fehlgeschlagen.",
+      "cannot_connect": "Verbindung zur API fehlgeschlagen.",
       "invalid_auth": "Ungültiger Benutzername oder Passwort.",
       "unknown": "Ein unerwarteter Fehler ist aufgetreten."
     },
@@ -73,7 +90,11 @@
       "salt_alert": { "name": "Salzalarm" },
       "leak_alert": { "name": "Leckagealarm" },
       "error_alert": { "name": "Systemfehleralarm" },
-      "alarm_beeping": { "name": "Alarmsummer" }
+      "alarm_beeping": { "name": "Alarmsummer" },
+      "connectivity": { "name": "Verbindung" }
+    },
+    "switch": {
+      "water_shutoff_valve": { "name": "Wasserabsperrventil" }
     }
   }
 }

--- a/custom_components/ecowater_hydrolink_custom/translations/en.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/en.json
@@ -3,6 +3,13 @@
     "step": {
       "user": {
         "title": "Ecowater Hydrolink Custom",
+        "description": "Select which EcoWater app your water softener uses.",
+        "data": {
+          "backend": "Cloud platform / app"
+        }
+      },
+      "hydrolink": {
+        "title": "Hydrolink login",
         "description": "Enter your Hydrolink login credentials to connect to your water softener.",
         "data": {
           "username": "Username (Email)",
@@ -11,10 +18,20 @@
           "unit_system": "Unit system",
           "scan_interval_minutes": "Update interval (minutes)"
         }
+      },
+      "iqua": {
+        "title": "iQua login",
+        "description": "Enter your iQua login credentials and device serial number (e.g. for Aquahome Duo Smart). The serial number can be found in the iQua app under your device's settings/info screen.",
+        "data": {
+          "username": "Username (Email)",
+          "password": "Password",
+          "device_serial_number": "Device serial number",
+          "scan_interval_minutes": "Update interval (minutes)"
+        }
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to the Hydrolink API.",
+      "cannot_connect": "Failed to connect to the API.",
       "invalid_auth": "Invalid username or password.",
       "unknown": "An unexpected error occurred."
     },
@@ -73,7 +90,11 @@
       "salt_alert": { "name": "Salt alert" },
       "leak_alert": { "name": "Leak alert" },
       "error_alert": { "name": "System error alert" },
-      "alarm_beeping": { "name": "Alarm beeping" }
+      "alarm_beeping": { "name": "Alarm beeping" },
+      "connectivity": { "name": "Connectivity" }
+    },
+    "switch": {
+      "water_shutoff_valve": { "name": "Water shutoff valve" }
     }
   }
 }

--- a/custom_components/ecowater_hydrolink_custom/translations/es.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/es.json
@@ -3,6 +3,13 @@
     "step": {
       "user": {
         "title": "Ecowater Hydrolink Custom",
+        "description": "Selecciona qué aplicación de EcoWater utiliza tu descalcificador de agua.",
+        "data": {
+          "backend": "Plataforma en la nube / app"
+        }
+      },
+      "hydrolink": {
+        "title": "Inicio de sesión Hydrolink",
         "description": "Introduce tus credenciales de Hydrolink Plus para conectar tu descalcificador de agua.",
         "data": {
           "username": "Nombre de usuario (Email)",
@@ -11,10 +18,20 @@
           "unit_system": "Sistema de unidades",
           "scan_interval_minutes": "Intervalo de actualización (minutos)"
         }
+      },
+      "iqua": {
+        "title": "Inicio de sesión iQua",
+        "description": "Introduce tus credenciales de iQua y el número de serie del dispositivo (p. ej. para Aquahome Duo Smart). El número de serie se encuentra en la app iQua, en la información/ajustes del dispositivo.",
+        "data": {
+          "username": "Nombre de usuario (Email)",
+          "password": "Contraseña",
+          "device_serial_number": "Número de serie del dispositivo",
+          "scan_interval_minutes": "Intervalo de actualización (minutos)"
+        }
       }
     },
     "error": {
-      "cannot_connect": "No se pudo conectar con la API de Hydrolink.",
+      "cannot_connect": "No se pudo conectar con la API.",
       "invalid_auth": "Nombre de usuario o contraseña inválidos.",
       "unknown": "Ocurrió un error inesperado."
     },
@@ -73,7 +90,11 @@
       "salt_alert": { "name": "Alarma de sal" },
       "leak_alert": { "name": "Alarma de fuga" },
       "error_alert": { "name": "Alarma de error del sistema" },
-      "alarm_beeping": { "name": "Zumbador de alarma" }
+      "alarm_beeping": { "name": "Zumbador de alarma" },
+      "connectivity": { "name": "Conectividad" }
+    },
+    "switch": {
+      "water_shutoff_valve": { "name": "Válvula de corte de agua" }
     }
   }
 }

--- a/custom_components/ecowater_hydrolink_custom/translations/fr.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/fr.json
@@ -3,6 +3,13 @@
     "step": {
       "user": {
         "title": "Ecowater Hydrolink Custom",
+        "description": "Sélectionnez l'application EcoWater utilisée par votre adoucisseur d'eau.",
+        "data": {
+          "backend": "Plateforme cloud / application"
+        }
+      },
+      "hydrolink": {
+        "title": "Connexion Hydrolink",
         "description": "Saisissez vos identifiants Hydrolink Plus pour connecter votre adoucisseur d'eau.",
         "data": {
           "username": "Nom d'utilisateur (Email)",
@@ -11,10 +18,20 @@
           "unit_system": "Système d'unités",
           "scan_interval_minutes": "Intervalle de mise à jour (minutes)"
         }
+      },
+      "iqua": {
+        "title": "Connexion iQua",
+        "description": "Saisissez vos identifiants iQua et le numéro de série de l'appareil (par ex. pour Aquahome Duo Smart). Le numéro de série se trouve dans l'application iQua, dans les informations/paramètres de l'appareil.",
+        "data": {
+          "username": "Nom d'utilisateur (Email)",
+          "password": "Mot de passe",
+          "device_serial_number": "Numéro de série de l'appareil",
+          "scan_interval_minutes": "Intervalle de mise à jour (minutes)"
+        }
       }
     },
     "error": {
-      "cannot_connect": "Échec de la connexion à l'API Hydrolink.",
+      "cannot_connect": "Échec de la connexion à l'API.",
       "invalid_auth": "Nom d'utilisateur ou mot de passe invalide.",
       "unknown": "Une erreur inattendue s'est produite."
     },
@@ -73,7 +90,11 @@
       "salt_alert": { "name": "Alarme sel" },
       "leak_alert": { "name": "Alarme fuite" },
       "error_alert": { "name": "Alarme erreur système" },
-      "alarm_beeping": { "name": "Avertisseur sonore" }
+      "alarm_beeping": { "name": "Avertisseur sonore" },
+      "connectivity": { "name": "Connectivité" }
+    },
+    "switch": {
+      "water_shutoff_valve": { "name": "Vanne d'arrêt d'eau" }
     }
   }
 }

--- a/custom_components/ecowater_hydrolink_custom/translations/it.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/it.json
@@ -3,6 +3,13 @@
     "step": {
       "user": {
         "title": "Ecowater Hydrolink Custom",
+        "description": "Seleziona quale app EcoWater utilizza il tuo addolcitore d'acqua.",
+        "data": {
+          "backend": "Piattaforma cloud / app"
+        }
+      },
+      "hydrolink": {
+        "title": "Accesso Hydrolink",
         "description": "Inserisci le tue credenziali Hydrolink Plus per connettere il tuo addolcitore d'acqua.",
         "data": {
           "username": "Nome utente (Email)",
@@ -11,10 +18,20 @@
           "unit_system": "Sistema di unità",
           "scan_interval_minutes": "Intervallo di aggiornamento (minuti)"
         }
+      },
+      "iqua": {
+        "title": "Accesso iQua",
+        "description": "Inserisci le tue credenziali iQua e il numero di serie del dispositivo (ad es. per Aquahome Duo Smart). Il numero di serie si trova nell'app iQua, nelle informazioni/impostazioni del dispositivo.",
+        "data": {
+          "username": "Nome utente (Email)",
+          "password": "Password",
+          "device_serial_number": "Numero di serie del dispositivo",
+          "scan_interval_minutes": "Intervallo di aggiornamento (minuti)"
+        }
       }
     },
     "error": {
-      "cannot_connect": "Impossibile connettersi all'API Hydrolink.",
+      "cannot_connect": "Impossibile connettersi all'API.",
       "invalid_auth": "Nome utente o password non validi.",
       "unknown": "Si è verificato un errore imprevisto."
     },
@@ -73,7 +90,11 @@
       "salt_alert": { "name": "Allarme sale" },
       "leak_alert": { "name": "Allarme perdita" },
       "error_alert": { "name": "Allarme errore sistema" },
-      "alarm_beeping": { "name": "Cicalino allarme" }
+      "alarm_beeping": { "name": "Cicalino allarme" },
+      "connectivity": { "name": "Connettività" }
+    },
+    "switch": {
+      "water_shutoff_valve": { "name": "Valvola di intercettazione acqua" }
     }
   }
 }

--- a/custom_components/ecowater_hydrolink_custom/translations/nl.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/nl.json
@@ -3,6 +3,13 @@
     "step": {
       "user": {
         "title": "Ecowater Hydrolink Custom",
+        "description": "Kies welke EcoWater app je waterontharder gebruikt.",
+        "data": {
+          "backend": "Cloud platform / app"
+        }
+      },
+      "hydrolink": {
+        "title": "Hydrolink inloggen",
         "description": "Voer je Hydrolink inloggegevens in om verbinding te maken met je waterontharder.",
         "data": {
           "username": "Gebruikersnaam (Email)",
@@ -11,10 +18,20 @@
           "unit_system": "Eenheidssysteem",
           "scan_interval_minutes": "Update interval (minuten)"
         }
+      },
+      "iqua": {
+        "title": "iQua inloggen",
+        "description": "Voer je iQua inloggegevens en het serienummer van je apparaat in (o.a. voor Aquahome Duo Smart). Het serienummer vind je in de iQua app bij de instellingen/info van je apparaat.",
+        "data": {
+          "username": "Gebruikersnaam (Email)",
+          "password": "Wachtwoord",
+          "device_serial_number": "Serienummer apparaat",
+          "scan_interval_minutes": "Update interval (minuten)"
+        }
       }
     },
     "error": {
-      "cannot_connect": "Verbinding met de Hydrolink API mislukt.",
+      "cannot_connect": "Verbinding met de API mislukt.",
       "invalid_auth": "Ongeldige gebruikersnaam of wachtwoord.",
       "unknown": "Er is een onverwachte fout opgetreden."
     },
@@ -73,7 +90,11 @@
       "salt_alert": { "name": "Zout alarm" },
       "leak_alert": { "name": "Lekkage alarm" },
       "error_alert": { "name": "Systeem fout alarm" },
-      "alarm_beeping": { "name": "Alarm zoemer" }
+      "alarm_beeping": { "name": "Alarm zoemer" },
+      "connectivity": { "name": "Verbinding" }
+    },
+    "switch": {
+      "water_shutoff_valve": { "name": "Water afsluitklep" }
     }
   }
 }

--- a/custom_components/ecowater_hydrolink_custom/translations/pl.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/pl.json
@@ -3,6 +3,13 @@
     "step": {
       "user": {
         "title": "Ecowater Hydrolink Custom",
+        "description": "Wybierz, której aplikacji EcoWater używa Twój zmiękczacz wody.",
+        "data": {
+          "backend": "Platforma chmurowa / aplikacja"
+        }
+      },
+      "hydrolink": {
+        "title": "Logowanie Hydrolink",
         "description": "Wprowadź swoje dane logowania do Hydrolink Plus, aby połączyć się ze zmiękczaczem wody.",
         "data": {
           "username": "Nazwa użytkownika (Email)",
@@ -11,10 +18,20 @@
           "unit_system": "System jednostek",
           "scan_interval_minutes": "Interwał aktualizacji (minuty)"
         }
+      },
+      "iqua": {
+        "title": "Logowanie iQua",
+        "description": "Wprowadź dane logowania iQua oraz numer seryjny urządzenia (np. dla Aquahome Duo Smart). Numer seryjny znajdziesz w aplikacji iQua w informacjach/ustawieniach urządzenia.",
+        "data": {
+          "username": "Nazwa użytkownika (Email)",
+          "password": "Hasło",
+          "device_serial_number": "Numer seryjny urządzenia",
+          "scan_interval_minutes": "Interwał aktualizacji (minuty)"
+        }
       }
     },
     "error": {
-      "cannot_connect": "Nie można połączyć się z API Hydrolink.",
+      "cannot_connect": "Nie można połączyć się z API.",
       "invalid_auth": "Nieprawidłowa nazwa użytkownika lub hasło.",
       "unknown": "Wystąpił nieoczekiwany błąd."
     },
@@ -73,7 +90,11 @@
       "salt_alert": { "name": "Alarm soli" },
       "leak_alert": { "name": "Alarm wycieku" },
       "error_alert": { "name": "Alarm błędu systemu" },
-      "alarm_beeping": { "name": "Sygnalizator dźwiękowy" }
+      "alarm_beeping": { "name": "Sygnalizator dźwiękowy" },
+      "connectivity": { "name": "Łączność" }
+    },
+    "switch": {
+      "water_shutoff_valve": { "name": "Zawór odcinający wodę" }
     }
   }
 }

--- a/custom_components/ecowater_hydrolink_custom/translations/pt.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/pt.json
@@ -3,6 +3,13 @@
     "step": {
       "user": {
         "title": "Ecowater Hydrolink Custom",
+        "description": "Selecione qual aplicação EcoWater o seu descalcificador de água utiliza.",
+        "data": {
+          "backend": "Plataforma cloud / aplicação"
+        }
+      },
+      "hydrolink": {
+        "title": "Início de sessão Hydrolink",
         "description": "Introduza as suas credenciais Hydrolink Plus para ligar o seu descalcificador de água.",
         "data": {
           "username": "Nome de utilizador (Email)",
@@ -11,10 +18,20 @@
           "unit_system": "Sistema de unidades",
           "scan_interval_minutes": "Intervalo de atualização (minutos)"
         }
+      },
+      "iqua": {
+        "title": "Início de sessão iQua",
+        "description": "Introduza as suas credenciais iQua e o número de série do dispositivo (por exemplo, para o Aquahome Duo Smart). O número de série encontra-se na app iQua, nas informações/definições do dispositivo.",
+        "data": {
+          "username": "Nome de utilizador (Email)",
+          "password": "Palavra-passe",
+          "device_serial_number": "Número de série do dispositivo",
+          "scan_interval_minutes": "Intervalo de atualização (minutos)"
+        }
       }
     },
     "error": {
-      "cannot_connect": "Falha na ligação à API Hydrolink.",
+      "cannot_connect": "Falha na ligação à API.",
       "invalid_auth": "Nome de utilizador ou palavra-passe inválidos.",
       "unknown": "Ocorreu um erro inesperado."
     },
@@ -73,7 +90,11 @@
       "salt_alert": { "name": "Alarme de sal" },
       "leak_alert": { "name": "Alarme de fuga" },
       "error_alert": { "name": "Alarme de erro do sistema" },
-      "alarm_beeping": { "name": "Sinal sonoro de alarme" }
+      "alarm_beeping": { "name": "Sinal sonoro de alarme" },
+      "connectivity": { "name": "Conectividade" }
+    },
+    "switch": {
+      "water_shutoff_valve": { "name": "Válvula de corte de água" }
     }
   }
 }


### PR DESCRIPTION
Adds a second cloud backend (apioem.ecowater.com) alongside the existing Hydrolink one, so devices controlled via the iQua app — such as the Aquahome Duo Smart — can be added.

Config flow now starts with a backend choice (Hydrolink vs iQua)
Existing Hydrolink entries migrate silently (v2 → v3), unaffected
New connectivity binary sensor and water_shutoff_valve switch (iQua only, disabled by default given it's a real physical action)
Shared HTTP retry logic factored out into net.py
All 8 translations + README updated

Not yet tested against a real device — built from the public iQua API contract used by an existing community project. Testing with a real Aquahome Duo Smart before merging is the main open item.