### PR TITLE
Validate Hydrolink credentials during config flow, log auth failure bodies

### DIFF
--- a/custom_components/ecowater_hydrolink_custom/config_flow.py
+++ b/custom_components/ecowater_hydrolink_custom/config_flow.py
@@ -1,8 +1,13 @@
 """Config flow for Ecowater Hydrolink Custom integration."""
+import asyncio
 import logging
+
+import async_timeout
 import voluptuous as vol
+from aiohttp.client_exceptions import ClientConnectorDNSError, ClientError
 from homeassistant import config_entries
 from homeassistant.core import callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     DOMAIN,
@@ -16,9 +21,53 @@ from .const import (
     UNIT_OPTIONS,
     SCAN_INTERVAL_MINUTES,
     DEFAULT_SCAN_INTERVAL,
+    BASE_URLS,
+    headers_for_region,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+async def _validate_login(hass, region, username, password):
+    """Attempt an actual login against the Hydrolink API to verify credentials.
+
+    Returns:
+        None if the credentials are valid, otherwise an error code
+        ("invalid_auth" or "cannot_connect") matching a key under
+        config.error in strings.json.
+    """
+    session = async_get_clientsession(hass)
+    login_url = f"{BASE_URLS[region]}/auth/login"
+    payload = {"email": username, "password": password}
+
+    try:
+        async with async_timeout.timeout(20):
+            response = await session.post(
+                login_url, json=payload, headers=headers_for_region(region)
+            )
+    except (ClientConnectorDNSError, ClientError, asyncio.TimeoutError) as err:
+        _LOGGER.warning("Could not reach Hydrolink API at %s: %s", login_url, err)
+        return "cannot_connect"
+
+    if response.status == 401:
+        body = await response.text()
+        _LOGGER.debug("Hydrolink login rejected (401) during setup: %s", body)
+        return "invalid_auth"
+    if response.status != 200:
+        body = await response.text()
+        _LOGGER.warning(
+            "Unexpected status %s from Hydrolink login during setup: %s",
+            response.status, body
+        )
+        return "cannot_connect"
+
+    data = await response.json()
+    if not (data.get("access_token") or data.get("token")):
+        _LOGGER.warning("Hydrolink login returned 200 but no token during setup: %s", data)
+        return "invalid_auth"
+
+    return None
+
 
 class EcowaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Ecowater Hydrolink Custom."""
@@ -30,24 +79,43 @@ class EcowaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            return self.async_create_entry(
-                title="Ecowater Hydrolink Custom",
-                data=user_input
+            error = await _validate_login(
+                self.hass,
+                user_input[CONF_REGION],
+                user_input[CONF_USERNAME],
+                user_input[CONF_PASSWORD],
             )
+            if error is None:
+                return self.async_create_entry(
+                    title="Ecowater Hydrolink Custom",
+                    data=user_input
+                )
+            errors["base"] = error
 
+        # Re-populate defaults from the previous attempt so a retry after a
+        # validation error doesn't force the user to redo their selections.
+        user_input = user_input or {}
+        username_field = (
+            vol.Required(CONF_USERNAME, default=user_input[CONF_USERNAME])
+            if CONF_USERNAME in user_input
+            else vol.Required(CONF_USERNAME)
+        )
         data_schema = vol.Schema(
             {
-                vol.Required(CONF_USERNAME): str,
+                username_field: str,
                 vol.Required(CONF_PASSWORD): str,
-                vol.Required(CONF_REGION, default=REGION_EU): vol.In(
+                vol.Required(CONF_REGION, default=user_input.get(CONF_REGION, REGION_EU)): vol.In(
                     {
                         REGION_EU: "Europe (app.hydrolinkhome.eu)",
                         REGION_US: "US / Other (app.hydrolinkhome.com)",
                     }
                 ),
-                vol.Required(CONF_UNIT_SYSTEM, default=UNIT_METRIC): vol.In(UNIT_OPTIONS),
+                vol.Required(
+                    CONF_UNIT_SYSTEM, default=user_input.get(CONF_UNIT_SYSTEM, UNIT_METRIC)
+                ): vol.In(UNIT_OPTIONS),
                 vol.Optional(
-                    SCAN_INTERVAL_MINUTES, default=DEFAULT_SCAN_INTERVAL
+                    SCAN_INTERVAL_MINUTES,
+                    default=user_input.get(SCAN_INTERVAL_MINUTES, DEFAULT_SCAN_INTERVAL)
                 ): int,
             }
         )

--- a/custom_components/ecowater_hydrolink_custom/const.py
+++ b/custom_components/ecowater_hydrolink_custom/const.py
@@ -29,14 +29,33 @@ BASE_URLS = {
 SCAN_INTERVAL_MINUTES = "scan_interval_minutes"
 DEFAULT_SCAN_INTERVAL = 5
 
+# Web app origins per region (used for the Origin/Referer headers below).
+APP_URLS = {
+    REGION_EU: "https://app.hydrolinkhome.eu",
+    REGION_US: "https://app.hydrolinkhome.com",
+}
+
 HEADERS = {
     "Accept": "application/json, text/plain, */*",
     "Accept-Language": "nl-NL,nl;q=0.9,en-US;q=0.8,en;q=0.7",
     "Content-Type": "application/json",
-    "Origin": "https://app.hydrolinkhome.eu",
-    "Referer": "https://app.hydrolinkhome.eu/",
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
     "X-Requested-With": "XMLHttpRequest",
 }
+
+
+def headers_for_region(region):
+    """Build request headers with Origin/Referer matching the selected region.
+
+    Previously Origin/Referer were hardcoded to the EU app URL for every
+    region, which doesn't match what the real US app would send.
+    """
+    app_url = APP_URLS.get(region, APP_URLS[REGION_EU])
+    return {
+        **HEADERS,
+        "Origin": app_url,
+        "Referer": f"{app_url}/",
+    }
+
 
 PLATFORMS = ["sensor", "binary_sensor"]

--- a/custom_components/ecowater_hydrolink_custom/coordinator.py
+++ b/custom_components/ecowater_hydrolink_custom/coordinator.py
@@ -8,7 +8,6 @@ import logging
 import asyncio
 from datetime import timedelta
 
-import aiohttp
 import async_timeout
 from aiohttp.client_exceptions import ClientConnectorDNSError, ClientError
 
@@ -25,7 +24,7 @@ from .const import (
     CONF_PASSWORD,
     CONF_UNIT_SYSTEM,
     UNIT_METRIC,
-    HEADERS,
+    headers_for_region,
     SCAN_INTERVAL_MINUTES,
     DEFAULT_SCAN_INTERVAL,
 )
@@ -142,7 +141,7 @@ class EcowaterCoordinator(DataUpdateCoordinator):
                 else:
                     _LOGGER.error("Max retries reached for %s %s", method, url)
                     raise
-            except Exception as err:
+            except Exception:
                 _LOGGER.exception("Unexpected error on %s %s", method, url)
                 raise
 
@@ -158,9 +157,15 @@ class EcowaterCoordinator(DataUpdateCoordinator):
         }
         try:
             response = await self._async_request(
-                "POST", self.login_url, json=auth_payload, headers=HEADERS
+                "POST", self.login_url, json=auth_payload, headers=headers_for_region(self.region)
             )
-            response.raise_for_status()
+            if response.status != 200:
+                body = await response.text()
+                _LOGGER.error(
+                    "Ecowater login failed with status %s for region %s: %s",
+                    response.status, self.region, body
+                )
+                return None
             data = await response.json()
             token = data.get("access_token") or data.get("token")
             if token:
@@ -168,7 +173,7 @@ class EcowaterCoordinator(DataUpdateCoordinator):
             else:
                 _LOGGER.error("No token in response: %s", data)
             return token
-        except Exception as ex:
+        except Exception:
             _LOGGER.exception("Authentication failed for Ecowater")
             return None
 
@@ -386,7 +391,7 @@ class EcowaterCoordinator(DataUpdateCoordinator):
         if not self.token:
             raise UpdateFailed("Could not log in to Ecowater (no token)")
 
-        headers = HEADERS.copy()
+        headers = headers_for_region(self.region)
         headers["Authorization"] = f"Bearer {self.token}"
 
         try:

--- a/custom_components/ecowater_hydrolink_custom/manifest.json
+++ b/custom_components/ecowater_hydrolink_custom/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ecowater_hydrolink_custom",
   "name": "Ecowater Hydrolink Custom",
-  "version": "1.4.0",
+  "version": "1.4.1-beta.1",
   "documentation": "https://github.com/roeli1996/ha-ecowater-hydrolink",
   "issue_tracker": "https://github.com/roeli1996/ha-ecowater-hydrolink/issues",
   "dependencies": [],


### PR DESCRIPTION
Fixes the setup flow reporting "Configuration created" even when the login credentials are wrong — the real failure only surfaced later as a generic ConfigEntryNotReady. The config flow now performs an actual login attempt before creating the entry, and shows invalid_auth/cannot_connect inline if it fails.

Also logs the response body on a failed login (previously only the HTTP status was visible), to help diagnose reports of unexpected 401s from the Hydrolink API. As a related fix, the Origin/Referer headers were hardcoded to the EU app URL for every region — they now follow the selected region.

Status: beta (1.4.1-beta.1), not yet confirmed to fix the underlying reported issue — see #13.