### PR TITLE
Fix invalid current_flow unit/device class, salt scaling, statistics units and unit-system attributes

### DIFF
--- a/custom_components/ecowater_hydrolink_custom/binary_sensor.py
+++ b/custom_components/ecowater_hydrolink_custom/binary_sensor.py
@@ -44,7 +44,7 @@ class EcoWaterBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._attr_unique_id = f"{DOMAIN}_bin_{data_key}_{coordinator.entry.entry_id}"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, coordinator.entry.entry_id)},
-            "name": "Ecowater Waterontharder",
+            "name": "Ecowater Water Softener",
             "manufacturer": "EcoWater",
             "model": coordinator.data.get("model") if coordinator.data else None,
         }

--- a/custom_components/ecowater_hydrolink_custom/coordinator.py
+++ b/custom_components/ecowater_hydrolink_custom/coordinator.py
@@ -32,6 +32,11 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# The API reports avg_salt_per_regen_lbs a thousand times larger than the
+# average implied by total_salt_use_lbs / total_regens, so it arrives in
+# thousandths of a pound rather than pounds.
+AVG_SALT_PER_REGEN_SCALE = 1000
+
 
 class EcowaterCoordinator(DataUpdateCoordinator):
     """Coordinator for periodically fetching Ecowater data.
@@ -222,6 +227,12 @@ class EcowaterCoordinator(DataUpdateCoordinator):
             prop = props.get(key, {})
             return prop.get("converted_value", default)
 
+        # Helper to rescale a raw API value that is reported in sub-units
+        def _scaled(value, divisor):
+            if value is None:
+                return None
+            return round(value / divisor, 2)
+
         # Helper to get the appropriate measurement based on the selected unit system
         def get_measurement(prop_key, default=None):
             if self.unit_system == UNIT_METRIC:
@@ -258,7 +269,10 @@ class EcowaterCoordinator(DataUpdateCoordinator):
             "water_available": get_measurement("treated_water_avail_gals"),
             "current_flow": get_measurement("current_water_flow_gpm"),
             "avg_daily_use": get_measurement("avg_daily_use_gals"),
-            "avg_salt_per_regen": get_measurement("avg_salt_per_regen_lbs"),
+            "avg_salt_per_regen": _scaled(
+                get_measurement("avg_salt_per_regen_lbs"),
+                AVG_SALT_PER_REGEN_SCALE,
+            ),
 
             # Other fields (not unit‑sensitive)
             "hardness": get_prop_value("hardness_grains"),
@@ -333,7 +347,7 @@ class EcowaterCoordinator(DataUpdateCoordinator):
 
             data["calculated_daily_use"] = self._daily_total
         else:
-            data["calculated_daily_use"] = 0
+            data["calculated_daily_use"] = 0.0
 
         # ----- Water used in the last regeneration -----
         # This calculates the amount of water consumed during the most recent regeneration cycle.

--- a/custom_components/ecowater_hydrolink_custom/sensor.py
+++ b/custom_components/ecowater_hydrolink_custom/sensor.py
@@ -3,7 +3,7 @@
 This module defines all sensor entities. It handles dynamic units:
 - Units that depend on the selected unit system (metric/imperial)
 - Units that should be translated according to the Home Assistant language
-  (e.g., "days", "times")
+  (e.g., "days")
 """
 
 import logging
@@ -12,6 +12,7 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,
 )
+from homeassistant.const import UnitOfTime, UnitOfVolumeFlowRate
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, UNIT_METRIC
 
@@ -30,17 +31,6 @@ DAYS_UNIT_TRANSLATIONS = {
     "pt": "dias",
 }
 
-TIMES_UNIT_TRANSLATIONS = {
-    "nl": "keer",
-    "en": "times",
-    "fr": "fois",
-    "de": "Mal",
-    "es": "veces",
-    "it": "volte",
-    "pl": "razy",
-    "pt": "vezes",
-}
-
 
 def get_days_unit(language):
     """Return the translated unit for "days" based on the Home Assistant language.
@@ -52,18 +42,6 @@ def get_days_unit(language):
         Translated unit string, or "days" as fallback.
     """
     return DAYS_UNIT_TRANSLATIONS.get(language, "days")
-
-
-def get_times_unit(language):
-    """Return the translated unit for "times" based on the Home Assistant language.
-
-    Args:
-        language: Two‑letter language code (e.g., "nl", "en").
-
-    Returns:
-        Translated unit string, or "times" as fallback.
-    """
-    return TIMES_UNIT_TRANSLATIONS.get(language, "times")
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
@@ -120,7 +98,9 @@ async def async_setup_entry(hass, entry, async_add_entities):
         ),
         EcoWaterSensor(
             coordinator, "current_flow", "current_flow",
-            "L/min", "gpm", SensorDeviceClass.WATER, SensorStateClass.MEASUREMENT
+            UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
+            UnitOfVolumeFlowRate.GALLONS_PER_MINUTE,
+            SensorDeviceClass.VOLUME_FLOW_RATE, SensorStateClass.MEASUREMENT
         ),
         EcoWaterSensor(
             coordinator, "avg_daily_use", "avg_daily_use",
@@ -130,7 +110,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
             coordinator, "hardness", "hardness",
             "gpg", "gpg", None, None
         ),
-        # Count‑based sensors (units are language‑dependent: "keer"/"times")
+        # Count‑based sensors
         EcoWaterSensor(
             coordinator, "total_regens", "total_regens",
             None, None, None, SensorStateClass.TOTAL_INCREASING
@@ -174,7 +154,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
         ),
         EcoWaterSensor(
             coordinator, "days_in_operation", "days_in_operation",
-            None, None, None, SensorStateClass.TOTAL_INCREASING
+            UnitOfTime.DAYS, UnitOfTime.DAYS, SensorDeviceClass.DURATION,
+            SensorStateClass.TOTAL_INCREASING
         ),
         EcoWaterSensor(
             coordinator, "power_outages", "power_outages",
@@ -317,7 +298,6 @@ class EcoWaterSensor(CoordinatorEntity, SensorEntity):
         if self._key in [
             "out_of_salt_days", "low_salt_trip_days",
             "days_since_regen", "avg_days_between_regens",
-            "days_in_operation"
         ]:
             unit = get_days_unit(self.coordinator.language)
             _LOGGER.debug(
@@ -326,14 +306,11 @@ class EcoWaterSensor(CoordinatorEntity, SensorEntity):
             )
             return unit
 
-        # Count‑based sensors (language‑dependent)
+        # total_regens and power_outages carry a state class, so their unit ends
+        # up in long-term statistics; a language-dependent unit would invalidate
+        # those the moment the user switches Home Assistant's language.
         if self._key in ["total_regens", "power_outages"]:
-            unit = get_times_unit(self.coordinator.language)
-            _LOGGER.debug(
-                "Sensor %s: language=%s, times unit=%s",
-                self.entity_id, self.coordinator.language, unit
-            )
-            return unit
+            return None
 
         # All other sensors: use the unit system (if applicable)
         if self._unit_metric is None:
@@ -368,6 +345,11 @@ class EcoWaterSensor(CoordinatorEntity, SensorEntity):
             metric = self.coordinator.data.get(key_metric)
             imperial = self.coordinator.data.get(key_imperial)
             if metric is None or imperial is None:
+                return
+            # Not every backend fills converted_value in: where it mirrors the
+            # raw value, publishing it would relabel the same number with the
+            # other unit system's unit.
+            if metric == imperial:
                 return
             if self.coordinator.unit_system == UNIT_METRIC:
                 attrs["imperial_value"] = imperial


### PR DESCRIPTION
Four separate correctness problems, all found on a US account (`api.hydrolinkhome.com`, EWS ERR3700R20, imperial unit system) and verified against the raw `detail-or-summary` payload.

## 1. `current_flow` has an invalid unit and device class

`current_flow` was declared as `SensorDeviceClass.WATER` with unit `gpm`. `water` is a **volume** device class, so Home Assistant rejects both the unit and the state class, and logs this on every reload:

```
Entity sensor.ecowater_water_softener_current_water_flow is using native unit of
measurement 'gpm' which is not a valid unit for the device class ('water')

Entity sensor.ecowater_water_softener_current_water_flow is using state class
'measurement' which is impossible considering device class ('water')
```

No statistics are recorded for the sensor as a result. It is a flow rate, so this switches it to `SensorDeviceClass.VOLUME_FLOW_RATE` with `UnitOfVolumeFlowRate.LITERS_PER_MINUTE` / `GALLONS_PER_MINUTE` (`gal/min` is the spelling Home Assistant accepts; `gpm` is not).

This is the underlying cause of #8, which was closed without the device class being changed.

## 2. `avg_salt_per_regen` is 1000x too large

Raw API values from my unit:

| property | value |
|---|---|
| `avg_salt_per_regen_lbs` | `23721` |
| `total_salt_use_lbs` | `4436` |
| `total_regens` | `187` |

`4436 / 187 = 23.72`, against a reported `23721`. The field arrives in thousandths of a pound while `total_salt_use_lbs` is in pounds, so the sensor showed "23721 lbs of salt per regeneration". Divided back to pounds.

## 3. Language-dependent units corrupt long-term statistics

`total_regens`, `power_outages` and `days_in_operation` all carry a `state_class`, so their unit is written into long-term statistics. Deriving that unit from the Home Assistant UI language means that **switching language changes the recorded unit and invalidates the stored statistics** for those sensors.

This changes only the three sensors that have a `state_class`:

- `total_regens`, `power_outages`: no unit (a bare count)
- `days_in_operation`: `SensorDeviceClass.DURATION` with `UnitOfTime.DAYS`, which Home Assistant localises for display on its own

The translated day units from #6 / #7 are **kept unchanged** on the sensors that have no state class (`out_of_salt_days`, `low_salt_trip_days`, `days_since_regen`, `avg_days_between_regens`).

Note for the release notes: existing users will get a one-time "unit changed" repair prompt for these three sensors. That is the intended migration, since the current behaviour silently breaks statistics on any language change.

## 4. The metric/imperial attributes relabel imperial values as metric

On the US backend `converted_value` is simply a copy of `value` for every property I checked:

```json
"total_salt_use_lbs":   {"value": 4436,  "converted_value": 4436},
"total_rock_removed_lbs": {"value": 2568, "converted_value": 2568},
"total_outlet_water_gals": {"value": 79562, "converted_value": 79562}
```

`add_alternate()` publishes `converted_value` as the metric reading regardless, so an imperial user gets `metric_value: 4436, metric_unit: "kg"` on a sensor whose state is `4436 lbs`: the same number, relabelled into another unit system.

This only skips the attribute pair when the two readings are identical, so backends that do populate a real conversion are unaffected.

## 5. Device registered under two different names

`binary_sensor.py` registered the device as `"Ecowater Waterontharder"` while `sensor.py` used `"Ecowater Water Softener"`, with the same `identifiers`. Whichever platform set up first won, so entity ids ended up split across both spellings on the same device:

```
sensor.ecowater_water_softener_salt_level
binary_sensor.ecowater_waterontharder_salt_alert
```

Aligned on the English name used by `sensor.py`.

## Not addressed here

Two further anomalies I could not resolve without knowing the intended API contract, and did not want to guess at:

- **`avg_days_between_regens`** reports `269`. With `days_in_operation` at `624` and `total_regens` at `187`, the real average is about 3.3 days, so the field looks like it is in hundredths. I left it alone rather than hard-code a divisor I cannot confirm on EU hardware.
- **`rock_removed_since_rech_lbs`** (`5464`) exceeds **`total_rock_removed_lbs`** (`2568`), which is impossible if both are pounds, so at least one of the two is mislabelled.

Happy to follow up on both if you can confirm what an EU device reports for those fields.
