### PR TITLE
Persist calculated daily usage across restarts

### DIFF
--- a/custom_components/ecowater_hydrolink_custom/__init__.py
+++ b/custom_components/ecowater_hydrolink_custom/__init__.py
@@ -12,6 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Ecowater Hydrolink Custom from a config entry."""
     coordinator = EcowaterCoordinator(hass, entry)
+    await coordinator.async_restore_daily_usage()
 
     try:
         await coordinator.async_config_entry_first_refresh()

--- a/custom_components/ecowater_hydrolink_custom/coordinator.py
+++ b/custom_components/ecowater_hydrolink_custom/coordinator.py
@@ -6,7 +6,7 @@ It acts as the central data hub for the integration.
 
 import logging
 import asyncio
-from datetime import timedelta
+from datetime import date, timedelta
 
 import aiohttp
 import async_timeout
@@ -14,6 +14,7 @@ from aiohttp.client_exceptions import ClientConnectorDNSError, ClientError
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -31,6 +32,11 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+STORAGE_VERSION = 1
+# Writes are debounced because the accumulator changes on every poll, but the
+# value only has to survive a restart.
+STORAGE_SAVE_DELAY = 60
 
 
 class EcowaterCoordinator(DataUpdateCoordinator):
@@ -85,6 +91,13 @@ class EcowaterCoordinator(DataUpdateCoordinator):
         self._daily_total = 0.0       # Accumulated usage since midnight
         self._last_date = None        # Date of the last update (used for reset)
 
+        # These accumulate across polls, so they have to outlive a restart or an
+        # options change; both tear the coordinator down and would otherwise
+        # zero the running day.
+        self._store = Store(
+            hass, STORAGE_VERSION, f"{DOMAIN}.{entry.entry_id}.daily_usage"
+        )
+
         # Variables for water used in the last regeneration
         self._prev_regen = False           # Previous regeneration state (True/False)
         self._water_at_regen_start = None  # Total water at start of regeneration
@@ -111,6 +124,49 @@ class EcowaterCoordinator(DataUpdateCoordinator):
         self.token = None
         self.session = async_get_clientsession(hass)
         _LOGGER.debug("Coordinator initialized")
+
+    async def async_restore_daily_usage(self):
+        """Reload the daily-usage accumulator saved by a previous run.
+
+        Must be awaited before the first refresh, otherwise the first poll
+        starts the day from zero again.
+        """
+        stored = await self._store.async_load()
+        if not stored:
+            _LOGGER.debug("No stored daily usage found, starting fresh")
+            return
+
+        try:
+            stored_date = stored.get("date")
+            self._last_date = date.fromisoformat(stored_date) if stored_date else None
+            self._daily_total = float(stored.get("daily_total", 0.0))
+            previous_total = stored.get("previous_total")
+            self._previous_total = (
+                float(previous_total) if previous_total is not None else None
+            )
+        except (TypeError, ValueError):
+            # A corrupt store must not block setup; the day simply restarts.
+            _LOGGER.warning("Stored daily usage unreadable, ignoring it")
+            self._last_date = None
+            self._daily_total = 0.0
+            self._previous_total = None
+            return
+
+        _LOGGER.debug(
+            "Restored daily usage: date=%s, daily_total=%s, previous_total=%s",
+            self._last_date, self._daily_total, self._previous_total
+        )
+
+    def _save_daily_usage(self):
+        """Queue a debounced write of the daily-usage accumulator."""
+        self._store.async_delay_save(
+            lambda: {
+                "date": self._last_date.isoformat() if self._last_date else None,
+                "daily_total": self._daily_total,
+                "previous_total": self._previous_total,
+            },
+            STORAGE_SAVE_DELAY,
+        )
 
     async def _async_request(self, method, url, **kwargs):
         """Perform an HTTP request with automatic retries on DNS/network errors.
@@ -331,6 +387,7 @@ class EcowaterCoordinator(DataUpdateCoordinator):
             # Store current total for next time
             self._previous_total = current_total
 
+            self._save_daily_usage()
             data["calculated_daily_use"] = self._daily_total
         else:
             data["calculated_daily_use"] = 0


### PR DESCRIPTION
`calculated_daily_use` loses the running day on every restart, and because the sensor carries a `state_class`, the loss is written into long-term statistics rather than just flickering on the dashboard.

Independent of #16, which touches different lines.

## The problem

The accumulator lives in coordinator instance attributes:

```python
self._previous_total = None   # Last known total water value
self._daily_total = 0.0       # Accumulated usage since midnight
self._last_date = None        # Date of the last update (used for reset)
```

`__init__` runs on every setup, so a restart or an options change (which goes through `update_listener` and reloads the entry) throws the day away. On the first poll afterwards:

- `_last_date is None`, so `_daily_total` is set to `0.0`
- `_previous_total is None`, so the delta is skipped

and the sensor publishes `0.0` in the middle of the day.

From my own instance, reloading at 10:48 with 50 gallons already accumulated:

```
07:50  50.0
10:48   0.0      <- reload, mid-day
```

The device itself reported 47 gallons used that day at the same moment, so the value was simply lost.

Because the sensor is `state_class: total_increasing`, Home Assistant reads that drop as a meter reset and records it. The corrupted daily total persists in statistics after the sensor recovers.

There is a second, quieter loss: even once the sensor starts counting again, the water consumed between the last poll before shutdown and the first poll after is never attributed to anything, since `_previous_total` starts empty.

## The fix

Persist the accumulator with `homeassistant.helpers.storage.Store` and reload it in `async_setup_entry` before the first refresh.

`previous_total` is stored in the same snapshot as `daily_total`, which makes a stale save harmless. On restore the next delta is measured from the stored `previous_total`, so it spans the downtime:

```
daily_total = stored_daily_total + (current_total - stored_previous_total)
```

That is the same result the sensor would have reached had it never restarted, so there is no need to flush on unload or to save synchronously.

Writes are debounced by 60 seconds because the value changes on every poll but only has to survive a restart. `Store` already flushes pending delayed writes on the Home Assistant final-write event, so a clean shutdown loses nothing.

A missing or unreadable store is not fatal: setup continues and the day simply starts from zero, which is today's behaviour.

## Notes

- New file in `.storage`: `ecowater_hydrolink_custom.<entry_id>.daily_usage`, one per config entry.
- No entity, unit or state class changes, so no statistics migration or repair prompt.
- Midnight rollover is unchanged. A restore whose stored date is not today still falls through the existing rollover branch and resets the day.

## Alternative worth considering

A daily total derived from a lifetime counter is exactly what the built-in `utility_meter` helper does, and it already handles restarts, resets and statistics correctly. If the intent of `calculated_daily_use` was only to work around `gallons_used_today` lagging behind the cloud, pointing users at a `utility_meter` on `total_water_used` would remove this state from the integration.

I have kept the sensor and fixed it in place, since removing it would be a breaking change and that call is yours.
