### PR TITLE
Support multiple devices under one Hydrolink account

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ The integration is fully configured via the Home Assistant user interface.
 6. Set the desired **update interval** in minutes (default 5 minutes; 1 minute also works).
 7. Click **Submit**.
 
+If your account has more than one device, you'll be asked to pick which one to add. **Repeat the whole "Add Integration" flow once per device** (same credentials each time) to add each device as its own entry.
+
 After successful configuration, all sensors and binary sensors will appear automatically under one device.
 
 ### Changing options
@@ -149,8 +151,10 @@ Attributes containing the alternative unit are only populated after the sensor h
 ### Unrealistic values for certain sensors
 Some sensors, such as `rock_removed_since_regen`, `total_rock_removed`, and `total_salt_use`, may display values that seem unrealistic (e.g., very high numbers for a newly installed device). These values come directly from the Hydrolink API and are not calculated or modified by the integration. They reflect the data provided by the manufacturer's cloud service.
 
+### Multiple devices under one account
+Starting from `1.4.2-beta.1`, adding the integration will show a device-selection step if your account has more than one device. Add the integration once per device (same credentials each time) - each becomes its own entry with its own sensors. Existing single-device setups are unaffected and don't need to be reconfigured.
+
 ### Known limitations
-- Not tested on multiple devices under a single account.
 - The `water_used_in_last_regen` sensor is experimental; its accuracy is not guaranteed and depends on the device's update behavior during regeneration.
 
 ## 📝 Changelog

--- a/custom_components/ecowater_hydrolink_custom/config_flow.py
+++ b/custom_components/ecowater_hydrolink_custom/config_flow.py
@@ -13,6 +13,7 @@ from .const import (
     DOMAIN,
     CONF_USERNAME,
     CONF_PASSWORD,
+    CONF_DEVICE_ID,
     CONF_REGION,
     REGION_EU,
     REGION_US,
@@ -28,45 +29,86 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-async def _validate_login(hass, region, username, password):
-    """Attempt an actual login against the Hydrolink API to verify credentials.
+def _device_label(device):
+    """Build a human-readable label for a device list entry.
+
+    Uses the same field paths as EcowaterCoordinator._parse_device_data()
+    so it stays consistent with what ends up in the "model" sensor.
+    """
+    serial = device.get("serial_number") or "?"
+    water_treatment = device.get("enriched_data", {}).get("water_treatment", {}) or {}
+    model = water_treatment.get("model")
+    if not model:
+        props = device.get("properties", {}) or {}
+        model = props.get("model_description", {}).get("value")
+    return f"{serial} ({model})" if model else serial
+
+
+async def _login_and_fetch_devices(hass, region, username, password):
+    """Log in and fetch the account's device list.
 
     Returns:
-        None if the credentials are valid, otherwise an error code
-        ("invalid_auth" or "cannot_connect") matching a key under
-        config.error in strings.json.
+        (devices, error) tuple. On success, `devices` is a non-empty list
+        of device dicts and `error` is None. On failure, `devices` is None
+        and `error` is a code ("invalid_auth", "cannot_connect" or
+        "no_devices") matching a key under config.error in strings.json.
     """
     session = async_get_clientsession(hass)
-    login_url = f"{BASE_URLS[region]}/auth/login"
-    payload = {"email": username, "password": password}
+    base_url = BASE_URLS[region]
+    headers = headers_for_region(region)
 
     try:
         async with async_timeout.timeout(20):
-            response = await session.post(
-                login_url, json=payload, headers=headers_for_region(region)
+            login_response = await session.post(
+                f"{base_url}/auth/login",
+                json={"email": username, "password": password},
+                headers=headers,
             )
     except (ClientConnectorDNSError, ClientError, asyncio.TimeoutError) as err:
-        _LOGGER.warning("Could not reach Hydrolink API at %s: %s", login_url, err)
-        return "cannot_connect"
+        _LOGGER.warning("Could not reach Hydrolink API at %s: %s", base_url, err)
+        return None, "cannot_connect"
 
-    if response.status == 401:
-        body = await response.text()
+    if login_response.status == 401:
+        body = await login_response.text()
         _LOGGER.debug("Hydrolink login rejected (401) during setup: %s", body)
-        return "invalid_auth"
-    if response.status != 200:
-        body = await response.text()
+        return None, "invalid_auth"
+    if login_response.status != 200:
+        body = await login_response.text()
         _LOGGER.warning(
             "Unexpected status %s from Hydrolink login during setup: %s",
-            response.status, body
+            login_response.status, body
         )
-        return "cannot_connect"
+        return None, "cannot_connect"
 
-    data = await response.json()
-    if not (data.get("access_token") or data.get("token")):
-        _LOGGER.warning("Hydrolink login returned 200 but no token during setup: %s", data)
-        return "invalid_auth"
+    login_data = await login_response.json()
+    token = login_data.get("access_token") or login_data.get("token")
+    if not token:
+        _LOGGER.warning("Hydrolink login returned 200 but no token during setup: %s", login_data)
+        return None, "invalid_auth"
 
-    return None
+    try:
+        async with async_timeout.timeout(20):
+            devices_response = await session.get(
+                f"{base_url}/devices?all=false&per_page=200",
+                headers={**headers, "Authorization": f"Bearer {token}"},
+            )
+    except (ClientConnectorDNSError, ClientError, asyncio.TimeoutError) as err:
+        _LOGGER.warning("Could not fetch Hydrolink device list: %s", err)
+        return None, "cannot_connect"
+
+    if devices_response.status != 200:
+        body = await devices_response.text()
+        _LOGGER.warning(
+            "Unexpected status %s fetching Hydrolink device list during setup: %s",
+            devices_response.status, body
+        )
+        return None, "cannot_connect"
+
+    devices = (await devices_response.json()).get("data", [])
+    if not devices:
+        return None, "no_devices"
+
+    return devices, None
 
 
 class EcowaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -74,22 +116,28 @@ class EcowaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 2
 
+    def __init__(self):
+        """Initialize the config flow's transient state."""
+        self._pending_data = None
+        self._devices = None
+
     async def async_step_user(self, user_input=None):
         """Step called when the user adds the integration."""
         errors = {}
 
         if user_input is not None:
-            error = await _validate_login(
+            devices, error = await _login_and_fetch_devices(
                 self.hass,
                 user_input[CONF_REGION],
                 user_input[CONF_USERNAME],
                 user_input[CONF_PASSWORD],
             )
             if error is None:
-                return self.async_create_entry(
-                    title="Ecowater Hydrolink Custom",
-                    data=user_input
-                )
+                self._pending_data = user_input
+                self._devices = devices
+                if len(devices) == 1:
+                    return await self._async_create_for_device(devices[0])
+                return await self.async_step_select_device()
             errors["base"] = error
 
         # Re-populate defaults from the previous attempt so a retry after a
@@ -125,6 +173,36 @@ class EcowaterConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=data_schema,
             errors=errors,
         )
+
+    async def async_step_select_device(self, user_input=None):
+        """For accounts with more than one device, let the user pick which one to add."""
+        if user_input is not None:
+            chosen_id = user_input[CONF_DEVICE_ID]
+            device = next(d for d in self._devices if str(d.get("id")) == chosen_id)
+            return await self._async_create_for_device(device)
+
+        device_options = {
+            str(device.get("id")): _device_label(device) for device in self._devices
+        }
+        data_schema = vol.Schema(
+            {vol.Required(CONF_DEVICE_ID): vol.In(device_options)}
+        )
+        return self.async_show_form(step_id="select_device", data_schema=data_schema)
+
+    async def _async_create_for_device(self, device):
+        """Create the config entry for a specific device.
+
+        Each device gets its own unique_id, so accounts with multiple
+        devices can add the integration once per device instead of always
+        ending up polling whichever device the API happens to list first.
+        """
+        device_id = device.get("id")
+        await self.async_set_unique_id(str(device_id))
+        self._abort_if_unique_id_configured()
+
+        data = {**self._pending_data, CONF_DEVICE_ID: device_id}
+        title = f"Ecowater Hydrolink Custom ({device.get('serial_number') or device_id})"
+        return self.async_create_entry(title=title, data=data)
 
     @staticmethod
     @callback

--- a/custom_components/ecowater_hydrolink_custom/const.py
+++ b/custom_components/ecowater_hydrolink_custom/const.py
@@ -6,6 +6,12 @@ NAME = "Ecowater Hydrolink Custom"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
 
+# Explicit device selection (for accounts with more than one Hydrolink
+# device). Older config entries created before this existed simply omit
+# this key, and the coordinator falls back to auto-selecting the first
+# device the account's device list returns - unchanged legacy behavior.
+CONF_DEVICE_ID = "device_id"
+
 # Region selection
 CONF_REGION = "region"
 REGION_EU = "EU"

--- a/custom_components/ecowater_hydrolink_custom/coordinator.py
+++ b/custom_components/ecowater_hydrolink_custom/coordinator.py
@@ -18,6 +18,7 @@ from homeassistant.util import dt as dt_util
 from .const import (
     DOMAIN,
     BASE_URLS,
+    CONF_DEVICE_ID,
     CONF_REGION,
     REGION_EU,
     CONF_USERNAME,
@@ -77,7 +78,11 @@ class EcowaterCoordinator(DataUpdateCoordinator):
         self.base_url = BASE_URLS[self.region]
         self.login_url = f"{self.base_url}/auth/login"
         self.devices_list_url = f"{self.base_url}/devices?all=false&per_page=200"
-        self.device_id = None  # Will be filled after first device list fetch
+        # Entries created via the device-selection step already know which
+        # device to poll. Older entries (created before that existed) omit
+        # this, so we fall back to auto-selecting the first device the
+        # account's device list returns - unchanged legacy behavior.
+        self.device_id = entry.data.get(CONF_DEVICE_ID)
 
         # Variables for calculated daily usage (derived from total_water_used)
         self._previous_total = None   # Last known total water value

--- a/custom_components/ecowater_hydrolink_custom/manifest.json
+++ b/custom_components/ecowater_hydrolink_custom/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ecowater_hydrolink_custom",
   "name": "Ecowater Hydrolink Custom",
-  "version": "1.4.1-beta.1",
+  "version": "1.4.2-beta.1",
   "documentation": "https://github.com/roeli1996/ha-ecowater-hydrolink",
   "issue_tracker": "https://github.com/roeli1996/ha-ecowater-hydrolink/issues",
   "dependencies": [],

--- a/custom_components/ecowater_hydrolink_custom/strings.json
+++ b/custom_components/ecowater_hydrolink_custom/strings.json
@@ -11,15 +11,23 @@
           "unit_system": "Unit system",
           "scan_interval_minutes": "Update interval (minutes)"
         }
+      },
+      "select_device": {
+        "title": "Select device",
+        "description": "Multiple devices were found on this account. Choose which one to add - you can add the integration again to add another.",
+        "data": {
+          "device_id": "Device"
+        }
       }
     },
     "error": {
       "cannot_connect": "Failed to connect to the Hydrolink API.",
       "invalid_auth": "Invalid username or password.",
+      "no_devices": "No devices found in this Hydrolink account.",
       "unknown": "An unexpected error occurred."
     },
     "abort": {
-      "already_configured": "This account is already configured."
+      "already_configured": "This device is already configured."
     }
   },
   "options": {

--- a/custom_components/ecowater_hydrolink_custom/translations/de.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/de.json
@@ -11,15 +11,23 @@
           "unit_system": "Einheitensystem",
           "scan_interval_minutes": "Aktualisierungsintervall (Minuten)"
         }
+      },
+      "select_device": {
+        "title": "Gerät auswählen",
+        "description": "Es wurden mehrere Geräte in diesem Konto gefunden. Wählen Sie aus, welches hinzugefügt werden soll - Sie können die Integration erneut hinzufügen, um ein weiteres Gerät hinzuzufügen.",
+        "data": {
+          "device_id": "Gerät"
+        }
       }
     },
     "error": {
       "cannot_connect": "Verbindung zur Hydrolink-API fehlgeschlagen.",
       "invalid_auth": "Ungültiger Benutzername oder Passwort.",
+      "no_devices": "Keine Geräte in diesem Hydrolink-Konto gefunden.",
       "unknown": "Ein unerwarteter Fehler ist aufgetreten."
     },
     "abort": {
-      "already_configured": "Dieses Konto ist bereits konfiguriert."
+      "already_configured": "Dieses Gerät ist bereits konfiguriert."
     }
   },
   "options": {

--- a/custom_components/ecowater_hydrolink_custom/translations/en.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/en.json
@@ -11,15 +11,23 @@
           "unit_system": "Unit system",
           "scan_interval_minutes": "Update interval (minutes)"
         }
+      },
+      "select_device": {
+        "title": "Select device",
+        "description": "Multiple devices were found on this account. Choose which one to add - you can add the integration again to add another.",
+        "data": {
+          "device_id": "Device"
+        }
       }
     },
     "error": {
       "cannot_connect": "Failed to connect to the Hydrolink API.",
       "invalid_auth": "Invalid username or password.",
+      "no_devices": "No devices found in this Hydrolink account.",
       "unknown": "An unexpected error occurred."
     },
     "abort": {
-      "already_configured": "This account is already configured."
+      "already_configured": "This device is already configured."
     }
   },
   "options": {

--- a/custom_components/ecowater_hydrolink_custom/translations/es.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/es.json
@@ -11,15 +11,23 @@
           "unit_system": "Sistema de unidades",
           "scan_interval_minutes": "Intervalo de actualización (minutos)"
         }
+      },
+      "select_device": {
+        "title": "Seleccionar dispositivo",
+        "description": "Se encontraron varios dispositivos en esta cuenta. Elige cuál quieres añadir - puedes volver a añadir la integración para agregar otro.",
+        "data": {
+          "device_id": "Dispositivo"
+        }
       }
     },
     "error": {
       "cannot_connect": "No se pudo conectar con la API de Hydrolink.",
       "invalid_auth": "Nombre de usuario o contraseña inválidos.",
+      "no_devices": "No se encontraron dispositivos en esta cuenta de Hydrolink.",
       "unknown": "Ocurrió un error inesperado."
     },
     "abort": {
-      "already_configured": "Esta cuenta ya está configurada."
+      "already_configured": "Este dispositivo ya está configurado."
     }
   },
   "options": {

--- a/custom_components/ecowater_hydrolink_custom/translations/fr.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/fr.json
@@ -11,15 +11,23 @@
           "unit_system": "Système d'unités",
           "scan_interval_minutes": "Intervalle de mise à jour (minutes)"
         }
+      },
+      "select_device": {
+        "title": "Sélectionner l'appareil",
+        "description": "Plusieurs appareils ont été trouvés sur ce compte. Choisissez celui à ajouter - vous pouvez ajouter l'intégration à nouveau pour ajouter un autre appareil.",
+        "data": {
+          "device_id": "Appareil"
+        }
       }
     },
     "error": {
       "cannot_connect": "Échec de la connexion à l'API Hydrolink.",
       "invalid_auth": "Nom d'utilisateur ou mot de passe invalide.",
+      "no_devices": "Aucun appareil trouvé sur ce compte Hydrolink.",
       "unknown": "Une erreur inattendue s'est produite."
     },
     "abort": {
-      "already_configured": "Ce compte est déjà configuré."
+      "already_configured": "Cet appareil est déjà configuré."
     }
   },
   "options": {

--- a/custom_components/ecowater_hydrolink_custom/translations/it.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/it.json
@@ -11,15 +11,23 @@
           "unit_system": "Sistema di unità",
           "scan_interval_minutes": "Intervallo di aggiornamento (minuti)"
         }
+      },
+      "select_device": {
+        "title": "Seleziona dispositivo",
+        "description": "Sono stati trovati più dispositivi su questo account. Scegli quale aggiungere - puoi aggiungere di nuovo l'integrazione per aggiungerne un altro.",
+        "data": {
+          "device_id": "Dispositivo"
+        }
       }
     },
     "error": {
       "cannot_connect": "Impossibile connettersi all'API Hydrolink.",
       "invalid_auth": "Nome utente o password non validi.",
+      "no_devices": "Nessun dispositivo trovato in questo account Hydrolink.",
       "unknown": "Si è verificato un errore imprevisto."
     },
     "abort": {
-      "already_configured": "Questo account è già configurato."
+      "already_configured": "Questo dispositivo è già configurato."
     }
   },
   "options": {

--- a/custom_components/ecowater_hydrolink_custom/translations/nl.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/nl.json
@@ -11,15 +11,23 @@
           "unit_system": "Eenheidssysteem",
           "scan_interval_minutes": "Update interval (minuten)"
         }
+      },
+      "select_device": {
+        "title": "Apparaat selecteren",
+        "description": "Er zijn meerdere apparaten gevonden op dit account. Kies welke je wil toevoegen - je kan de integratie opnieuw toevoegen om een ander apparaat toe te voegen.",
+        "data": {
+          "device_id": "Apparaat"
+        }
       }
     },
     "error": {
       "cannot_connect": "Verbinding met de Hydrolink API mislukt.",
       "invalid_auth": "Ongeldige gebruikersnaam of wachtwoord.",
+      "no_devices": "Geen apparaten gevonden op dit Hydrolink-account.",
       "unknown": "Er is een onverwachte fout opgetreden."
     },
     "abort": {
-      "already_configured": "Dit account is al geconfigureerd."
+      "already_configured": "Dit apparaat is al geconfigureerd."
     }
   },
   "options": {

--- a/custom_components/ecowater_hydrolink_custom/translations/pl.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/pl.json
@@ -11,15 +11,23 @@
           "unit_system": "System jednostek",
           "scan_interval_minutes": "Interwał aktualizacji (minuty)"
         }
+      },
+      "select_device": {
+        "title": "Wybierz urządzenie",
+        "description": "Na tym koncie znaleziono więcej niż jedno urządzenie. Wybierz, które chcesz dodać - możesz ponownie dodać integrację, aby dodać kolejne urządzenie.",
+        "data": {
+          "device_id": "Urządzenie"
+        }
       }
     },
     "error": {
       "cannot_connect": "Nie można połączyć się z API Hydrolink.",
       "invalid_auth": "Nieprawidłowa nazwa użytkownika lub hasło.",
+      "no_devices": "Nie znaleziono urządzeń na tym koncie Hydrolink.",
       "unknown": "Wystąpił nieoczekiwany błąd."
     },
     "abort": {
-      "already_configured": "To konto jest już skonfigurowane."
+      "already_configured": "To urządzenie jest już skonfigurowane."
     }
   },
   "options": {

--- a/custom_components/ecowater_hydrolink_custom/translations/pt.json
+++ b/custom_components/ecowater_hydrolink_custom/translations/pt.json
@@ -11,15 +11,23 @@
           "unit_system": "Sistema de unidades",
           "scan_interval_minutes": "Intervalo de atualização (minutos)"
         }
+      },
+      "select_device": {
+        "title": "Selecionar dispositivo",
+        "description": "Foram encontrados vários dispositivos nesta conta. Escolha qual pretende adicionar - pode adicionar a integração novamente para adicionar outro dispositivo.",
+        "data": {
+          "device_id": "Dispositivo"
+        }
       }
     },
     "error": {
       "cannot_connect": "Falha na ligação à API Hydrolink.",
       "invalid_auth": "Nome de utilizador ou palavra-passe inválidos.",
+      "no_devices": "Não foram encontrados dispositivos nesta conta Hydrolink.",
       "unknown": "Ocorreu um erro inesperado."
     },
     "abort": {
-      "already_configured": "Esta conta já está configurada."
+      "already_configured": "Este dispositivo já está configurado."
     }
   },
   "options": {


### PR DESCRIPTION
Fixes accounts with multiple Hydrolink devices only ever getting the first one set up, no matter how many times the integration was added. Adding the integration now shows a device-selection step when more than one device is found; each device gets its own config entry. Existing single-device setups are unaffected. Fixes #19.